### PR TITLE
Fix normalization issue

### DIFF
--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -373,14 +373,12 @@ class DataManager(object):
                 # convert _run_number to int if it can be
                 try:
                     _run_number = int(data_xs.configuration.normalization)
-                except:
-                    # TODO 93 - good to catch specific type of exception
+                except (ValueError, TypeError):
                     _run_number = data_xs.configuration.normalization
                 # convert item.number to int if it can be
                 try:
-                    item_number = int(item_number)
-                except:
-                    # TODO 93 - good to catch specific type of exception
+                    item_number = int(item.number)
+                except (ValueError, TypeError):
                     item_number = item.number
                 if item_number == _run_number:
                     keys = item.cross_sections.keys()

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -370,11 +370,19 @@ class DataManager(object):
 
         if data_xs.configuration is not None and data_xs.configuration.normalization is not None:
             for item in self.direct_beam_list:
+                # convert _run_number to int if it can be
                 try:
                     _run_number = int(data_xs.configuration.normalization)
                 except:
+                    # TODO 93 - good to catch specific type of exception
                     _run_number = data_xs.configuration.normalization
-                if item.number == _run_number:
+                # convert item.number to int if it can be
+                try:
+                    item_number = int(item_number)
+                except:
+                    # TODO 93 - good to catch specific type of exception
+                    item_number = item.number
+                if item_number == _run_number:
                     keys = item.cross_sections.keys()
                     if len(keys) >= 1:
                         if len(keys) > 1:
@@ -418,7 +426,7 @@ class DataManager(object):
         # We must have a direct beam data set to normalize with
         direct_beam = self._find_direct_beam(nexus_data)
         if direct_beam is None:
-	    # TODO 67 Handle this error with GUI prompt GUI
+            # TODO 67 Handle this error with GUI prompt GUI
             raise RuntimeError("Please select a direct beam data set for your data.")
 
         nexus_data.calculate_gisans(direct_beam=direct_beam, progress=progress)

--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -328,6 +328,7 @@ class MainHandler(object):
         def _reset_ui_file_list(fresh_list):
             r"""reset widget self.ui.file_list and highlight the current file_name"""
             self.ui.file_list.clear()  # Reset ui.file_list, a QtWidgets.QListWidget object
+            assert isinstance(fresh_list, list), 'fresh_list must be list but not {}'.format(type(fresh_list))
             for item in fresh_list:
                 listitem = QtWidgets.QListWidgetItem(item, self.ui.file_list)
                 if item == self._data_manager.current_file_name:
@@ -373,6 +374,9 @@ class MainHandler(object):
                     _update_current_directory(file_dir)
                     self._data_manager.current_file_name = self._data_manager.current_event_files[0]
                     new_list = self._data_manager.current_event_files
+                else:
+                    # TODO FIXME discovered from #93.  This path is not checked and thus problematic
+                    new_list = None
             # Use case 3.2: a single path pointing to a file in the current or new directory
             else:
                 file_dir, file_name = file_path.split()
@@ -382,8 +386,10 @@ class MainHandler(object):
                 else:  # User selected a new file in a new directory
                     _update_current_directory(file_dir)
                     new_list = self._data_manager.current_event_files
-        _reset_ui_file_list(new_list)
-        self.main_window.auto_change_active = False
+        # TODO FIXME  - new_list is not None has not been defined by stakeholder
+        if new_list is not None:
+            _reset_ui_file_list(new_list)
+            self.main_window.auto_change_active = False
 
     def automated_file_selection(self):
         """


### PR DESCRIPTION
This is to fix https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/93.

**Investigation**

 - The normalization is at https://github.com/neutrons/reflectivity_ui/blob/master/reflectivity_ui/interfaces/data_handling/data_set.py#L184.
It is called by https://github.com/neutrons/reflectivity_ui/blob/master/reflectivity_ui/interfaces/data_manager.py#L489

- Line https://github.com/neutrons/reflectivity_ui/blob/master/reflectivity_ui/interfaces/data_manager.py#L482 fails to find the direct beam.
Bug: https://github.com/neutrons/reflectivity_ui/blob/master/reflectivity_ui/interfaces/data_manager.py#L377

- item.number from self.direct_beam_list is string

- _run_number is an integer if it is can be converted to an integer. Otherwise it is a string.

**Planned Solution**: convert to item.number to integer if it can. Otherwise, keep it as original type.