### PR TITLE
added settings.json as package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if 'pyrcc' in sys.argv[:]:
     os.system(command)
     sys.exit(0)
 
-package_data = {"reflectivity_ui.interfaces.data_handling": ["genx_templates/*.gx",]}
+package_data = {"reflectivity_ui.interfaces.data_handling": ["genx_templates/*.gx",], "reflectivity_ui.config": ["./*.json"]}
 
 setup(name="reflectivity_ui",
       version=reflectivity_ui.__version__,


### PR DESCRIPTION
This adds settings.json to package_data so that it appears next to the compile python files, this *should* fix the file not found issue on next release. Still need to manually add and test it on the cluster.