### PR TITLE
WIP: Revert latest change to test ci, it was passing up till now

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -62,7 +62,7 @@ jobs:
     if: ${{ github.ref_protected || github.ref_type == 'tag' }}
     steps:
       - name: Determine Environment
-        uses: neutrons/branch-mapper@v2
+        uses: neutrons/branch-mapper@main
         id: conda_env_name
         with:
           prefix: quicknxs2


### PR DESCRIPTION
This reverts commit 7bd90ff7d214572413ed18b4ea44bc7aa1c1af6a.

Its either this or upstream dependencies are now failing and we should perhaps pin a mantid version