### PR TITLE
fix defect 1267: broken IO

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/quicknxs_io.py
+++ b/reflectivity_ui/interfaces/data_handling/quicknxs_io.py
@@ -248,7 +248,7 @@ def write_reflectivity_data(output_path, data, col_names, as_5col=True):
             for tof_item in data:
                 for pixel_item in tof_item:
                     np.savetxt(fd, pixel_item, delimiter="\t", fmt="%-18e")
-                    fd.write("\n".encode("utf8"))
+                    fd.write("\n")
         else:
             if four_cols:
                 np.savetxt(fd, data[:, :4], delimiter=" ", fmt="%-18e")


### PR DESCRIPTION
Defect 1267 describes broken IO when saving off-specular data.