### PR TITLE
Change filtering option

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/instrument.py
+++ b/reflectivity_ui/interfaces/data_handling/instrument.py
@@ -28,7 +28,7 @@ if application_conf.mantid_path is not None:
 import mantid.simpleapi as api
 
 # Option to use the slow flipper logs rather than the Analyzer/Polarizer logs
-USE_SLOW_FLIPPER_LOG = True
+USE_SLOW_FLIPPER_LOG = False
 
 # Constants
 h = 6.626e-34  # m^2 kg s^-1


### PR DESCRIPTION
The Magnetism Reflectometer has a new analyzer, which will change the options available for data filtering.
At the moment there are two implemented options, but the one used should not be used by default.

This PR just changes the flag to tell which option to use. This should eventually be an option in the UI.