### PR TITLE
Add unit test for stitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <!-- Badges -->
 
-![Build Status](https://github.com/neutrons/reflectivity_ui/actions/workflows/ornl-prod.yml/badge.svg)
-![Unittest Status](https://github.com/neutrons/reflectivity_ui/actions/workflows/unittest.yml/badge.svg?branch=next)
-[![TRAVISCI](https://travis-ci.org/neutrons/reflectivity_ui.svg?branch=master)](https://travis-ci.org/neutrons/reflectivity_ui)
+![Build Status](https://github.com/neutrons/reflectivity_ui/actions/workflows/actions.yml/badge.svg)
 [![codecov](https://codecov.io/gh/neutrons/reflectivity_ui/branch/master/graph/badge.svg)](https://codecov.io/gh/neutrons/reflectivity_ui)
 
 <!-- End Badges -->

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pytest
 - pytest-qt
 - pytest-cov
+- pytest-mock
 - pytest-xvfb
 - toml
 - pip

--- a/reflectivity_ui/interfaces/data_handling/data_manipulation.py
+++ b/reflectivity_ui/interfaces/data_handling/data_manipulation.py
@@ -184,6 +184,7 @@ def smart_stitch_reflectivity(reduction_list, xs=None, normalize_to_unity=True, 
     """
     Stitch and normalize data sets
 
+    :param list[NexusData] reduction_list: list of data sets to stitch
     :param string xs: name of the cross-section to use for the first data set
     :param bool normalize_to_unity: if True, the specular ridge will be normalized to 1
     """

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -111,7 +111,7 @@ class NexusData(object):
     """
 
     def __init__(self, file_path, configuration):
-        # type: (unicode, Configurati0n) -> None
+        # type: (unicode, Configuration) -> None
         """
         @brief Structure to read in one or more Nexus data files
         @param file_path: absolute path to one or more files. If more than one, paths are concatenated with the

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -42,12 +42,12 @@ def mocker_file_open(mocker):
 @pytest.fixture
 def stitching_config():
     settings = {
-        'use_dangle': True,
-        'normalize_to_unity': False,
-        'total_reflectivity_q_cutoff': 0.008,
-        'do_final_rebin': False,
-        'final_rebin_step': -0.01,
-        'match_direct_beam': True
+        "use_dangle": True,
+        "normalize_to_unity": False,
+        "total_reflectivity_q_cutoff": 0.008,
+        "do_final_rebin": False,
+        "final_rebin_step": -0.01,
+        "match_direct_beam": True,
     }
     config = Configuration()
     for key in settings:

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -4,33 +4,33 @@ from reflectivity_ui.interfaces.configuration import Configuration
 from reflectivity_ui.interfaces.data_handling.data_manipulation import smart_stitch_reflectivity
 from reflectivity_ui.interfaces.data_manager import DataManager
 
-
-mock_reduced_file_str = """# Datafile created by QuickNXS 3.1.0.dev2
-# Datafile created using Mantid 6.6.0
-# Date: 2023-07-05 13:31:21
-# Type: Specular
-# Input file indices: 42112,42116,42113
-# Extracted states: -+
-#
-# [Direct Beam Runs]
-#    DB_ID        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width      dpix       tth    number      File
-#        1         0         0       195        12     126.5       155        55        24       194         0     42099  /SNS/REF_M/IPTS-30794/nexus/REF_M_42099.nxs.h5
-#        2         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5
-#        3         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5
-#
-# [Data Runs]
-#    scale        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width       fan      dpix       tth    number     DB_ID      File
-#        1        15        10       167        12     163.5      72.9        55        24     False       194  0.00653668     42112         1  /SNS/REF_M/IPTS-30794/nexus/REF_M_42112.nxs.h5
-# 0.183654        15        10     189.3        12     162.2      68.3        55        24     False       194  0.799577     42116         2  /SNS/REF_M/IPTS-30794/nexus/REF_M_42116.nxs.h5
-#   0.1375        15        10     167.5        12     159.9      67.4        55        24     False       194  0.798876     42113         3  /SNS/REF_M/IPTS-30794/nexus/REF_M_42113.nxs.h5
-#
-# [Global Options]
-# name           value
-# sample_length  10.0
-#
-# [Data]
-#     Qz [1/A]	    R [a.u.]	   dR [a.u.]	   dQz [1/A]
-"""
+mock_reduced_file_str = (
+    "# Datafile created by QuickNXS 3.1.0.dev2\n"
+    "# Datafile created using Mantid 6.6.0\n"
+    "# Date: 2023-07-05 13:31:21\n"
+    "# Type: Specular\n"
+    "# Input file indices: 42112,42116,42113\n"
+    "# Extracted states: -+\n"
+    "#\n"
+    "# [Direct Beam Runs]\n"
+    "#    DB_ID        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width      dpix       tth    number      File\n"  # noqa: E501
+    "#        1         0         0       195        12     126.5       155        55        24       194         0     42099  /SNS/REF_M/IPTS-30794/nexus/REF_M_42099.nxs.h5\n"  # noqa: E501
+    "#        2         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5\n"  # noqa: E501
+    "#        3         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5\n"  # noqa: E501
+    "#\n"
+    "# [Data Runs]\n"
+    "#    scale        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width       fan      dpix       tth    number     DB_ID      File\n"  # noqa: E501
+    "#        1        15        10       167        12     163.5      72.9        55        24     False       194  0.00653668     42112         1  /SNS/REF_M/IPTS-30794/nexus/REF_M_42112.nxs.h5\n"  # noqa: E501
+    "# 0.183654        15        10     189.3        12     162.2      68.3        55        24     False       194  0.799577     42116         2  /SNS/REF_M/IPTS-30794/nexus/REF_M_42116.nxs.h5\n"  # noqa: E501
+    "#   0.1375        15        10     167.5        12     159.9      67.4        55        24     False       194  0.798876     42113         3  /SNS/REF_M/IPTS-30794/nexus/REF_M_42113.nxs.h5\n"  # noqa: E501
+    "#\n"
+    "# [Global Options]\n"
+    "# name           value\n"
+    "# sample_length  10.0\n"
+    "#\n"
+    "# [Data]\n"
+    "#     Qz [1/A]	    R [a.u.]	   dR [a.u.]	   dQz [1/A]"
+)
 
 
 @pytest.fixture

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -1,0 +1,73 @@
+import pytest
+
+from reflectivity_ui.interfaces.configuration import Configuration
+from reflectivity_ui.interfaces.data_handling.data_manipulation import smart_stitch_reflectivity
+from reflectivity_ui.interfaces.data_manager import DataManager
+
+
+mock_reduced_file_str = """# Datafile created by QuickNXS 3.1.0.dev2
+# Datafile created using Mantid 6.6.0
+# Date: 2023-07-05 13:31:21
+# Type: Specular
+# Input file indices: 42112,42116,42113
+# Extracted states: -+
+#
+# [Direct Beam Runs]
+#    DB_ID        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width      dpix       tth    number      File
+#        1         0         0       195        12     126.5       155        55        24       194         0     42099  /SNS/REF_M/IPTS-30794/nexus/REF_M_42099.nxs.h5
+#        2         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5
+#        3         0         0       195        12       127       154        55        24       194         0     42100  /SNS/REF_M/IPTS-30794/nexus/REF_M_42100.nxs.h5
+#
+# [Data Runs]
+#    scale        P0        PN     x_pos   x_width     y_pos   y_width    bg_pos  bg_width       fan      dpix       tth    number     DB_ID      File
+#        1        15        10       167        12     163.5      72.9        55        24     False       194  0.00653668     42112         1  /SNS/REF_M/IPTS-30794/nexus/REF_M_42112.nxs.h5
+# 0.183654        15        10     189.3        12     162.2      68.3        55        24     False       194  0.799577     42116         2  /SNS/REF_M/IPTS-30794/nexus/REF_M_42116.nxs.h5
+#   0.1375        15        10     167.5        12     159.9      67.4        55        24     False       194  0.798876     42113         3  /SNS/REF_M/IPTS-30794/nexus/REF_M_42113.nxs.h5
+#
+# [Global Options]
+# name           value
+# sample_length  10.0
+#
+# [Data]
+#     Qz [1/A]	    R [a.u.]	   dR [a.u.]	   dQz [1/A]
+"""
+
+
+@pytest.fixture
+def mocker_file_open(mocker):
+    mocked_reduced_file = mocker.mock_open(read_data=mock_reduced_file_str)
+    mocker.patch("builtins.open", mocked_reduced_file)
+
+
+@pytest.fixture
+def stitching_config():
+    settings = {
+        'use_dangle': True,
+        'normalize_to_unity': False,
+        'total_reflectivity_q_cutoff': 0.008,
+        'do_final_rebin': False,
+        'final_rebin_step': -0.01,
+        'match_direct_beam': True
+    }
+    config = Configuration()
+    for key in settings:
+        setattr(config, key, settings[key])
+    return config
+
+
+class TestDataManipulation(object):
+    def test_smart_stitch_reflectivity(self, data_server, mocker_file_open, stitching_config):
+        manager = DataManager(data_server.directory)
+        try:
+            manager.load_data_from_reduced_file("note: file read is mocked", stitching_config)
+            if len(manager.reduction_list) < 1:
+                raise IOError("Files missing.")
+        except IOError:
+            pytest.skip("Cannot find required datafiles, probably not being run on the cluster.")
+
+        scaling_factors = smart_stitch_reflectivity(manager.reduction_list, None, False, 0.008)
+        assert scaling_factors == pytest.approx([1.0, 0.1809, 0.1354], abs=0.001)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/unit/reflectivity_ui/interfaces/test_data_manager.py
+++ b/test/unit/reflectivity_ui/interfaces/test_data_manager.py
@@ -55,12 +55,9 @@ class TestDataManagerTest(object):
         assert len(manager.reduction_list) == 3
 
         for i in range(len(manager.reduction_list) - 1):
-            ws = manager.reduction_list[i].get_reflectivity_workspace_group()[0]
-            theta = ws.getRun().getProperty("two_theta").value
-
-            _ws = manager.reduction_list[i + 1].get_reflectivity_workspace_group()[0]
-            _theta = _ws.getRun().getProperty("two_theta").value
-            assert theta <= _theta
+            q_min, _ = manager.reduction_list[i].get_q_range()
+            _q_min, _ = manager.reduction_list[i + 1].get_q_range()
+            assert q_min <= _q_min
 
     def test_load_reduced(self, data_server):
         manager = DataManager(data_server.directory)

--- a/test/unit/reflectivity_ui/interfaces/test_data_manager.py
+++ b/test/unit/reflectivity_ui/interfaces/test_data_manager.py
@@ -55,9 +55,12 @@ class TestDataManagerTest(object):
         assert len(manager.reduction_list) == 3
 
         for i in range(len(manager.reduction_list) - 1):
-            q_min, _ = manager.reduction_list[i].get_q_range()
-            _q_min, _ = manager.reduction_list[i + 1].get_q_range()
-            assert q_min <= _q_min
+            ws = manager.reduction_list[i].get_reflectivity_workspace_group()[0]
+            theta = ws.getRun().getProperty("two_theta").value
+
+            _ws = manager.reduction_list[i + 1].get_reflectivity_workspace_group()[0]
+            _theta = _ws.getRun().getProperty("two_theta").value
+            assert theta <= _theta
 
     def test_load_reduced(self, data_server):
         manager = DataManager(data_server.directory)


### PR DESCRIPTION
This is part of [Story 1577: [QuickNXS3] use selected cross-section to stitch data](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1577).

This PR creates a unit test for stitching, however, it can only be run on the analysis cluster (or with the analysis cluster directory /SNS/REF_M mounted).