### PR TITLE
Correct error bars of stitched reflectivity curves

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - conda-forge
     - default
 dependencies:
-- mantidworkbench>=6.7.20230803,<6.8
+- mantidworkbench>=6.7.20230822,<6.8
 - anaconda-client
 - boa
 - build

--- a/reflectivity_ui/interfaces/configuration.py
+++ b/reflectivity_ui/interfaces/configuration.py
@@ -73,6 +73,8 @@ class Configuration(object):
         self.subtract_background = True
         # Overall scaling factor
         self.scaling_factor = 1.0
+        # Error in the scaling factor
+        self.scaling_error = 0.0
         # Normalize to unity when stitching
         self.normalize_to_unity = True
         self.total_reflectivity_q_cutoff = 0.01
@@ -191,6 +193,7 @@ class Configuration(object):
 
         settings.setValue("subtract_background", self.subtract_background)
         settings.setValue("scaling_factor", self.scaling_factor)
+        settings.setValue("scaling_error", self.scaling_error)
         settings.setValue("cut_first_n_points", self.cut_first_n_points)
         settings.setValue("cut_last_n_points", self.cut_last_n_points)
 
@@ -277,6 +280,7 @@ class Configuration(object):
 
         self.subtract_background = _verify_true("subtract_background", self.subtract_background)
         self.scaling_factor = float(settings.value("scaling_factor", self.scaling_factor))
+        self.scaling_error = float(settings.value("scaling_error", self.scaling_error))
         self.cut_first_n_points = int(settings.value("cut_first_n_points", self.cut_first_n_points))
         self.cut_last_n_points = int(settings.value("cut_last_n_points", self.cut_last_n_points))
 

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -590,7 +590,9 @@ class CrossSectionData(object):
     def dr(self):
         if self._dr is None:
             return None
-        return self._dr * self.configuration.scaling_factor
+        return np.sqrt(
+            (self._dr * self.configuration.scaling_factor) ** 2 + (self.configuration.scaling_error * self._r) ** 2
+        )
 
     @property
     def wavelength_range(self):

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -117,7 +117,7 @@ class TestDataManipulation(object):
             raise IOError("Files missing.")
         scaling_factors, scaling_errors = smart_stitch_reflectivity(manager.reduction_list, "Off_On", False, 0.008)
         assert scaling_factors == pytest.approx([1.0, 0.1809, 0.1556], abs=0.001)
-        assert scaling_errors == pytest.approx([0.0, 0.0, 0.0], abs=0.001)
+        assert scaling_errors == pytest.approx([0.0, 0.003, 0.005], abs=0.001)
 
     @pytest.mark.parametrize(
         "normalize_to_unity, q_cutoff, global_fit, expected_scaling_factors, expected_scaling_errors",


### PR DESCRIPTION
Resolves [Defect 2208: [QuickNXS] Correct Error Bars in Stitched Data](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2208)

- Add new attribute `scaling_error` to the `Configuration` object
- Do error propagation of scaling factor errors in `smart_stitch_reflectivity`
- Add unit tests