### PR TITLE
Stitching by fitting a polynomial

### DIFF
--- a/reflectivity_ui/interfaces/configuration.py
+++ b/reflectivity_ui/interfaces/configuration.py
@@ -80,6 +80,10 @@ class Configuration(object):
         self.total_reflectivity_q_cutoff = 0.01
         # Use all cross-sections when stitching
         self.global_stitching = False
+        # Use a polynomial curve fit when stitching
+        self.polynomial_stitching = False
+        self.polynomial_stitching_degree = 3
+        self.polynomial_stitching_points = 3
 
         # Cut first and last N points
         self.cut_first_n_points = 1
@@ -201,6 +205,9 @@ class Configuration(object):
         settings.setValue("normalize_to_unity", self.normalize_to_unity)
         settings.setValue("total_reflectivity_q_cutoff", self.total_reflectivity_q_cutoff)
         settings.setValue("global_stitching", self.global_stitching)
+        settings.setValue("polynomial_stitching", self.polynomial_stitching)
+        settings.setValue("polynomial_stitching_degree", self.polynomial_stitching_degree)
+        settings.setValue("polynomial_stitching_points", self.polynomial_stitching_points)
 
         settings.setValue("normalize_x_tof", self.normalize_x_tof)
         settings.setValue("x_wl_map", self.x_wl_map)
@@ -290,6 +297,13 @@ class Configuration(object):
             settings.value("total_reflectivity_q_cutoff", self.total_reflectivity_q_cutoff)
         )
         self.global_stitching = _verify_true("global_stitching", self.global_stitching)
+        self.polynomial_stitching = _verify_true("polynomial_stitching", self.polynomial_stitching)
+        self.polynomial_stitching_degree = int(
+            settings.value("polynomial_stitching_degree", self.polynomial_stitching_degree)
+        )
+        self.polynomial_stitching_points = int(
+            settings.value("polynomial_stitching_points", self.polynomial_stitching_points)
+        )
 
         self.normalize_x_tof = _verify_true("normalize_x_tof", self.normalize_x_tof)
         self.x_wl_map = _verify_true("x_wl_map", self.x_wl_map)

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -580,7 +580,7 @@ class DataManager(object):
                 n_points = len(item.cross_sections[xs].q) - overlap_idx[0][0]
                 item.set_parameter("cut_last_n_points", n_points)
 
-    def stitch_data_sets(self, normalize_to_unity=True, q_cutoff=0.01, global_stitching=False):
+    def stitch_data_sets(self, normalize_to_unity=True, q_cutoff=0.01, global_stitching=False, polynomial=None):
         """
         Determine scaling factors for each data set
         :param bool normalize_to_unity: If True, the reflectivity plateau will be normalized to 1.
@@ -588,7 +588,7 @@ class DataManager(object):
         :param bool global_stitching: If True, use data from all cross-sections to calculate scaling factors
         """
         data_manipulation.smart_stitch_reflectivity(
-            self.reduction_list, self.active_channel.name, normalize_to_unity, q_cutoff, global_stitching
+            self.reduction_list, self.active_channel.name, normalize_to_unity, q_cutoff, global_stitching, polynomial
         )
 
     def merge_data_sets(self, asymmetry=True):

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -580,15 +580,25 @@ class DataManager(object):
                 n_points = len(item.cross_sections[xs].q) - overlap_idx[0][0]
                 item.set_parameter("cut_last_n_points", n_points)
 
-    def stitch_data_sets(self, normalize_to_unity=True, q_cutoff=0.01, global_stitching=False, polynomial=None):
+    def stitch_data_sets(
+        self, normalize_to_unity=True, q_cutoff=0.01, global_stitching=False, poly_degree=None, poly_points=3
+    ):
         """
         Determine scaling factors for each data set
         :param bool normalize_to_unity: If True, the reflectivity plateau will be normalized to 1.
         :param float q_cutoff: critical q-value below which we expect R=1
         :param bool global_stitching: If True, use data from all cross-sections to calculate scaling factors
+        :param int poly_degree: if not None, find the scaling factor by simultaneously fitting a polynomial and scaling factor to the curves
+        :param int poly_points: number of additional points on each end of the overlap region to include in the fit
         """
         data_manipulation.smart_stitch_reflectivity(
-            self.reduction_list, self.active_channel.name, normalize_to_unity, q_cutoff, global_stitching, polynomial
+            self.reduction_list,
+            self.active_channel.name,
+            normalize_to_unity,
+            q_cutoff,
+            global_stitching,
+            poly_degree,
+            poly_points,
         )
 
     def merge_data_sets(self, asymmetry=True):

--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -1266,10 +1266,15 @@ class MainHandler(object):
         # Update the configuration so we can remember the cutoff value
         # later if it was changed
         self.get_configuration()
+        if self.ui.polynomial_stitching_checkbox.isChecked():
+            polynomial_degree = self.ui.polynomial_stitching_degree_spinbox.value()
+        else:
+            polynomial_degree = None
         self._data_manager.stitch_data_sets(
             normalize_to_unity=self.ui.normalize_to_unity_checkbox.isChecked(),
             q_cutoff=self.ui.normalization_q_cutoff_spinbox.value(),
             global_stitching=self.ui.global_fit_checkbox.isChecked(),
+            polynomial=polynomial_degree,
         )
 
         for i in range(len(self._data_manager.reduction_list)):

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -717,8 +717,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>397</width>
-             <height>288</height>
+             <width>484</width>
+             <height>350</height>
             </rect>
            </property>
            <attribute name="label">
@@ -813,7 +813,7 @@
               </property>
              </widget>
             </item>
-            <item row="9" column="1" colspan="2">
+            <item row="11" column="1" colspan="2">
              <widget class="QCheckBox" name="fanReflectivity">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Evaluate Q for each X line of the reflectivity and combine these measurements.&lt;/p&gt;&lt;p&gt;Can be used with a large X-width of e.g. 15 for samples scattering to a large 2θ area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -895,7 +895,7 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
+            <item row="13" column="1">
              <widget class="QLabel" name="label_31">
               <property name="minimumSize">
                <size>
@@ -908,7 +908,7 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="2">
+            <item row="13" column="2">
              <widget class="QDoubleSpinBox" name="sample_size_spinbox">
               <property name="suffix">
                <string> mm</string>
@@ -924,14 +924,14 @@
               </property>
              </widget>
             </item>
-            <item row="11" column="1">
+            <item row="14" column="1">
              <widget class="QLabel" name="label_53">
               <property name="text">
                <string>Bandwidth:</string>
               </property>
              </widget>
             </item>
-            <item row="11" column="2">
+            <item row="14" column="2">
              <widget class="QDoubleSpinBox" name="bandwidth_spinbox">
               <property name="toolTip">
                <string>Bandwidth to use to select the TOF range when loading data.</string>
@@ -957,6 +957,26 @@
               </property>
              </widget>
             </item>
+            <item row="9" column="1">
+             <widget class="QCheckBox" name="polynomial_stitching_checkbox">
+              <property name="text">
+               <string>Polynomial fit when stitching</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="1">
+             <widget class="QLabel" name="label_56">
+              <property name="text">
+               <string>Polynomial degree</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="2">
+             <widget class="QSpinBox" name="polynomial_stitching_degree_spinbox"/>
+            </item>
            </layout>
            <zorder>trustSANGLE</zorder>
            <zorder>trustDANGLE</zorder>
@@ -974,6 +994,9 @@
            <zorder>label_53</zorder>
            <zorder>bandwidth_spinbox</zorder>
            <zorder>global_fit_checkbox</zorder>
+           <zorder>polynomial_stitching_checkbox</zorder>
+           <zorder>label_56</zorder>
+           <zorder>polynomial_stitching_degree_spinbox</zorder>
           </widget>
           <widget class="QWidget" name="page_3">
            <property name="geometry">

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -718,7 +718,7 @@
              <x>0</x>
              <y>0</y>
              <width>484</width>
-             <height>350</height>
+             <height>386</height>
             </rect>
            </property>
            <attribute name="label">
@@ -813,7 +813,7 @@
               </property>
              </widget>
             </item>
-            <item row="11" column="1" colspan="2">
+            <item row="12" column="1" colspan="2">
              <widget class="QCheckBox" name="fanReflectivity">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Evaluate Q for each X line of the reflectivity and combine these measurements.&lt;/p&gt;&lt;p&gt;Can be used with a large X-width of e.g. 15 for samples scattering to a large 2θ area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -895,7 +895,7 @@
               </property>
              </widget>
             </item>
-            <item row="13" column="1">
+            <item row="14" column="1">
              <widget class="QLabel" name="label_31">
               <property name="minimumSize">
                <size>
@@ -908,7 +908,7 @@
               </property>
              </widget>
             </item>
-            <item row="13" column="2">
+            <item row="14" column="2">
              <widget class="QDoubleSpinBox" name="sample_size_spinbox">
               <property name="suffix">
                <string> mm</string>
@@ -924,14 +924,14 @@
               </property>
              </widget>
             </item>
-            <item row="14" column="1">
+            <item row="15" column="1">
              <widget class="QLabel" name="label_53">
               <property name="text">
                <string>Bandwidth:</string>
               </property>
              </widget>
             </item>
-            <item row="14" column="2">
+            <item row="15" column="2">
              <widget class="QDoubleSpinBox" name="bandwidth_spinbox">
               <property name="toolTip">
                <string>Bandwidth to use to select the TOF range when loading data.</string>
@@ -957,6 +957,13 @@
               </property>
              </widget>
             </item>
+            <item row="10" column="2">
+             <widget class="QSpinBox" name="polynomial_stitching_degree_spinbox">
+              <property name="value">
+               <number>3</number>
+              </property>
+             </widget>
+            </item>
             <item row="9" column="1">
              <widget class="QCheckBox" name="polynomial_stitching_checkbox">
               <property name="text">
@@ -974,8 +981,22 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="2">
-             <widget class="QSpinBox" name="polynomial_stitching_degree_spinbox"/>
+            <item row="11" column="1">
+             <widget class="QLabel" name="label_57">
+              <property name="text">
+               <string>Points outside overlap</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="2">
+             <widget class="QSpinBox" name="polynomial_stitching_points_spinbox">
+              <property name="value">
+               <number>3</number>
+              </property>
+             </widget>
             </item>
            </layout>
            <zorder>trustSANGLE</zorder>
@@ -997,6 +1018,8 @@
            <zorder>polynomial_stitching_checkbox</zorder>
            <zorder>label_56</zorder>
            <zorder>polynomial_stitching_degree_spinbox</zorder>
+           <zorder>label_57</zorder>
+           <zorder>polynomial_stitching_points_spinbox</zorder>
           </widget>
           <widget class="QWidget" name="page_3">
            <property name="geometry">

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -130,10 +130,10 @@ class TestDataManipulation(object):
             (True, False, None, [0.2, 0.33333, 1.0], [0.02, 0.057735, 0.22361]),
             (False, True, None, [1.0, 2.4, 6.0], [0.0, 0.24403, 0.85988]),
             (True, True, None, [0.2, 0.48, 1.2], [0.02, 0.068455, 0.20970]),
-            (False, False, 3, [1.0, 1.66667, 5.0], [0.0, 0.22754, 0.95711]),
-            (True, False, 3, [0.2, 0.33333, 1.0], [0.02, 0.056410, 0.21597]),
-            (False, True, 3, [1.0, 2.4, 6.0], [0.0, 0.23164, 0.83919]),
-            (True, True, 3, [0.2, 0.48, 1.2], [0.02, 0.066711, 0.20632]),
+            (False, False, 3, [1.0, 1.66667, 5.0], [0.0, 0.2, 1.0]),
+            (True, False, 3, [0.2, 0.33333, 1.0], [0.02, 0.06, 0.2]),
+            (False, True, 3, [1.0, 2.4, 6.0], [0.0, 0.2, 0.9]),
+            (True, True, 3, [0.2, 0.48, 1.2], [0.02, 0.07, 0.2]),
         ],
     )
     def test_smart_stitch_parameters(
@@ -155,7 +155,8 @@ class TestDataManipulation(object):
             stitching_reduction_list, "On_On", normalize_to_unity, q_cutoff, global_fit, polynom_degree
         )
         assert scaling_factors == pytest.approx(expected_scaling_factors, abs=0.001)
-        assert scaling_errors == pytest.approx(expected_scaling_errors, abs=0.001)
+        # higher tolerance because the polynomial fit to a constant value is ill-conditioned
+        assert scaling_errors == pytest.approx(expected_scaling_errors, rel=0.2)
         # Delete workspaces
         api.mtd.clear()
 

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -190,20 +190,22 @@ class TestDataManipulation(object):
 
         Tests stitching of two parts of a parabola x^2 with no overlap in the x-range
         """
+        rng = np.random.default_rng(745841)
+
         x1 = np.arange(0, 10)
-        y1 = x1**2
+        y1 = x1**2 + rng.normal(0.0, 0.001)
         ws1 = api.CreateWorkspace(x1, y1)
 
         expected_scale_factor = 3.2
         x2 = np.arange(12, 20)
-        y2 = x2**2 / expected_scale_factor
+        y2 = x2**2 / expected_scale_factor + rng.normal(0.0, 0.001)
         ws2 = api.CreateWorkspace(x2, y2)
 
         # test expected output
         fit_output = _get_polynomial_fit_stitching_scaling_factor(ws1, ws2, 3, 3)
-        assert fit_output["scale_factor_value"] == pytest.approx(expected_scale_factor)
-        assert fit_output["scale_factor_error"] == pytest.approx(0.172152)
-        assert fit_output["polynomial_coeff"] == pytest.approx([0.0, 0.0, 1.0, 0.0], abs=1e-6)
+        assert fit_output["scale_factor_value"] == pytest.approx(expected_scale_factor, abs=1e-3)
+        assert fit_output["scale_factor_error"] == pytest.approx(0.26968, abs=1e-3)
+        assert fit_output["polynomial_coeff"] == pytest.approx([0.0, 0.0, 1.0, 0.0], abs=1e-2)
 
         # test exception due to not enough points
         with pytest.raises(RuntimeError) as error_info:


### PR DESCRIPTION
This resolves [Story 834: [QUICKNXS3] Add polynomial fit to stitching](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=834)

The current stitching functionality requires that the two reflectivity curves overlap in Q by at least one point. The new option allows users to stitch two curves that do not overlap, by fitting a polynomial to the low-Q curve and the same polynomial multiplied by a scaling factor to the high-Q curve, as illustrated here (by @jmborr):

![image](https://github.com/neutrons/reflectivity_ui/assets/6989921/375918de-5292-4e0f-af99-8e384d4da22f)

Add to the GUI: checkbox for whether to use polynomial fit, number entries for polynomial degree and number of points outside the overlap to use.
In function `smart_stitch_reflectivity`, add new polynomial fit parameters and logic to simultaneously fit a polynomial and a scaling factor to the two curves to stitch.

![image](https://github.com/neutrons/reflectivity_ui/assets/6989921/a6c774fc-7429-409d-aeb5-5cd948c823ac)
