### PR TITLE
State of checkbox "Normalize to unity when stitching" is not persistent

### DIFF
--- a/bin/RefRedM
+++ b/bin/RefRedM
@@ -2,7 +2,6 @@
 """
     Start script for reduction application
 """
-from __future__ import absolute_import, division, print_function
 import sys
 import os
 import types

--- a/bin/quicknxs2
+++ b/bin/quicknxs2
@@ -2,7 +2,6 @@
 """
     Start script for reduction application
 """
-from __future__ import absolute_import, division, print_function
 import sys
 import os
 import types

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -444,6 +444,7 @@ class CrossSectionData(object):
     dangle0 = 0
     det_size_x = 0.0007
     det_size_y = 0.0007
+    lambda_center = 0
 
     def __init__(self, name, configuration, entry_name="entry", workspace=None):
         self.name = name

--- a/reflectivity_ui/interfaces/main_window.py
+++ b/reflectivity_ui/interfaces/main_window.py
@@ -170,12 +170,18 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         self.file_handler.open_file(self.data_manager.current_file, force=True)
 
-    def changeActiveChannel(self):
+    def change_active_channel(self, is_checked):
         """
-        The overview and reflectivity channel was changed. This
-        recalculates already extracted reflectivities.
+        The overview and reflectivity channel was changed. This updates the run
+        information and plots in the Overview area
+
+        The toggled() signal is emitted from both radio buttons whose states were changed,
+        therefore, use the bool value to only perform channel update actions once.
+
+        :param bool is_checked: the state of the radio button that emitted the signal
         """
-        return self.file_loaded()
+        if is_checked:
+            self.file_handler.active_channel_changed()
 
     def getNorm(self):
         """

--- a/reflectivity_ui/ui/compare_plots.py
+++ b/reflectivity_ui/ui/compare_plots.py
@@ -3,7 +3,6 @@
 """
   Widget to compare different reflectivities.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import os
 import logging

--- a/reflectivity_ui/ui/mplwidget.py
+++ b/reflectivity_ui/ui/mplwidget.py
@@ -5,8 +5,6 @@
 
     #TODO: refactor this or replace it with a standard solution
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import inspect
 import tempfile

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -396,7 +396,7 @@
           <property name="currentIndex">
            <number>1</number>
           </property>
-          <widget class="QWidget" name="page">
+          <widget class="QWidget" name="reflectivity_extraction_basic">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -712,7 +712,7 @@
             </item>
            </layout>
           </widget>
-          <widget class="QWidget" name="page_2">
+          <widget class="QWidget" name="reflectivity_extraction_advanced">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -964,7 +964,7 @@
               </property>
              </widget>
             </item>
-            <item row="9" column="1">
+            <item row="9" column="1" colspan="2">
              <widget class="QCheckBox" name="polynomial_stitching_checkbox">
               <property name="text">
                <string>Polynomial fit when stitching</string>
@@ -1021,7 +1021,7 @@
            <zorder>label_57</zorder>
            <zorder>polynomial_stitching_points_spinbox</zorder>
           </widget>
-          <widget class="QWidget" name="page_3">
+          <widget class="QWidget" name="peak_finder">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -5888,9 +5888,9 @@
   </connection>
   <connection>
    <sender>selectedChannel0</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1430</x>
@@ -5904,9 +5904,9 @@
   </connection>
   <connection>
    <sender>selectedChannel1</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1512</x>
@@ -5920,9 +5920,9 @@
   </connection>
   <connection>
    <sender>selectedChannel2</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1595</x>
@@ -5936,9 +5936,9 @@
   </connection>
   <connection>
    <sender>selectedChannel3</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1677</x>
@@ -6000,9 +6000,9 @@
   </connection>
   <connection>
    <sender>selectedChannel4</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1430</x>
@@ -6016,9 +6016,9 @@
   </connection>
   <connection>
    <sender>selectedChannel5</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1512</x>
@@ -6032,9 +6032,9 @@
   </connection>
   <connection>
    <sender>selectedChannel6</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1595</x>
@@ -6048,9 +6048,9 @@
   </connection>
   <connection>
    <sender>selectedChannel7</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1677</x>
@@ -6064,9 +6064,9 @@
   </connection>
   <connection>
    <sender>selectedChannel8</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1430</x>
@@ -6080,9 +6080,9 @@
   </connection>
   <connection>
    <sender>selectedChannel9</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1512</x>
@@ -6096,9 +6096,9 @@
   </connection>
   <connection>
    <sender>selectedChannel10</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1595</x>
@@ -6112,9 +6112,9 @@
   </connection>
   <connection>
    <sender>selectedChannel11</sender>
-   <signal>released()</signal>
+   <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>file_loaded()</slot>
+   <slot>change_active_channel()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1677</x>
@@ -6462,7 +6462,7 @@
   <slot>reduceDatasets()</slot>
   <slot>normalizeTotalReflection()</slot>
   <slot>reductionTableChanged(QTableWidgetItem*)</slot>
-  <slot>file_loaded()</slot>
+  <slot>change_active_channel()</slot>
   <slot>removeRefList()</slot>
   <slot>changeRegionValues()</slot>
   <slot>refineXpos()</slot>

--- a/test/ui/test_main_window.py
+++ b/test/ui/test_main_window.py
@@ -1,4 +1,5 @@
 # local imports
+from reflectivity_ui.interfaces.data_handling.data_set import CrossSectionData, NexusData
 from reflectivity_ui.interfaces.main_window import MainWindow
 from test import SNS_REFM_MOUNTED
 from test.ui import ui_utilities
@@ -29,6 +30,36 @@ class TestMainGui:
         assert window_main.file_handler.get_configuration().global_stitching is True
         window_main.global_fit_checkbox.setChecked(False)
         assert window_main.file_handler.get_configuration().global_stitching is False
+
+    def test_active_channel(self, mocker, qtbot):
+        """Test that selecting a cross-section radio button updates the active channel"""
+        # mock updating the plots
+        mocker.patch("reflectivity_ui.interfaces.main_window.MainWindow.plotActiveTab", return_value=True)
+        mocker.patch("reflectivity_ui.interfaces.plotting.PlotManager.plot_refl", return_value=True)
+        mocker.patch("reflectivity_ui.interfaces.plotting.PlotManager.plot_projections", return_value=True)
+
+        # create the SUT
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+
+        # set up data objects for two channels
+        configuration = window_main.file_handler.get_configuration()
+        channel0 = CrossSectionData("On_Off", configuration)
+        channel1 = CrossSectionData("On_On", configuration)
+        nexus_data = NexusData("filepath", configuration)
+        nexus_data.cross_sections = {channel0.name: channel0, channel1.name: channel1}
+        window_main.data_manager._nexus_data = nexus_data
+        window_main.data_manager.set_channel(0)
+
+        assert window_main.data_manager.active_channel.name == channel0.name
+
+        # change the selected channel
+        window_main.selectedChannel1.setChecked(True)
+
+        # check the active channel in the data manager
+        assert window_main.data_manager.active_channel.name == channel1.name
+        # check the current channel name displayed in the UI
+        assert channel1.name in window_main.ui.currentChannel.text()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves [Defect 2298: [QUICKNXS] State of checkbox "Normalize to unity when stitching" is not persistent when selecting a different cross-section](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2298)

Whenever a different cross-section was selected, the function [file_loaded](https://github.com/neutrons/reflectivity_ui/blob/next/reflectivity_ui/interfaces/event_handlers/main_handler.py#L143) was called, which led to many unnecessary updates.
One side-effect was that all reduction options, like the checkbox "Normalize to unity when stitching", where re-populated from the settings stored on the selected cross-section.

Description of changes:
- For connecting with the cross-section radio button, create a separate function for updates strictly related to changing the active cross-section. For example: cross-section metadata like proton charge, and various plots
- Change the cross-section radio button signal from `released()` to `toggled()` to be able to create UI unit tests with `setChecked()` (which only emits the signal `toggled()`)