### PR TITLE
Display error message when "Normalize to unity when stitching" fails

### DIFF
--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -7,6 +7,7 @@
 
 
 # package imports
+from reflectivity_ui.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
 from ..configuration import Configuration
 from .progress_reporter import ProgressReporter
 from .widgets import AcceptRejectDialog
@@ -1328,9 +1329,16 @@ class MainHandler(object):
                 poly_degree=poly_degree,
                 poly_points=self.ui.polynomial_stitching_points_spinbox.value(),
             )
-        except RuntimeError as err:
+        except (RuntimeError, ValueError) as err:
             self.report_message(
                 f"Error in stitching:\n{str(err)}",
+                detailed_message=str(traceback.format_exc()),
+                pop_up=True,
+                is_error=True,
+            )
+        except NormalizeToUnityQCutoffError as err:
+            self.report_message(
+                f"Error in normalize to unity when stitching:\n{str(err)}",
                 detailed_message=str(traceback.format_exc()),
                 pop_up=True,
                 is_error=True,

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_manipulation.py
@@ -1,6 +1,7 @@
 # package imports
 from reflectivity_ui.interfaces.configuration import Configuration
 from reflectivity_ui.interfaces.data_handling.data_manipulation import (
+    NormalizeToUnityQCutoffError,
     _get_polynomial_fit_stitching_scaling_factor,
     _get_stitching_overlap_region,
     smart_stitch_reflectivity,
@@ -212,6 +213,12 @@ class TestDataManipulation(object):
         with pytest.raises(RuntimeError) as error_info:
             _get_polynomial_fit_stitching_scaling_factor(ws1, ws2, 5, 3)
         assert "Levenberg-Marquardt minimizer failed to initialize" in str(error_info.value)
+
+    def test_smart_stitch_normalize_to_unity_error(self, stitching_reduction_list):
+        """Test that error is raised when the normalize to unity Q cutoff is too low"""
+        q_cutoff = 0.5
+        with pytest.raises(NormalizeToUnityQCutoffError):
+            smart_stitch_reflectivity(stitching_reduction_list, "On_On", True, q_cutoff)
 
 
 if __name__ == "__main__":

--- a/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
@@ -1,9 +1,11 @@
 # package imports
+from reflectivity_ui.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
 from reflectivity_ui.interfaces.main_window import MainWindow
 from reflectivity_ui.interfaces.event_handlers.main_handler import MainHandler
 
 # 3rd-party imports
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
 import pytest
 
 # standard imports
@@ -56,6 +58,25 @@ class TestMainHandler(object):
             [data_server.path_to("REF_M_38198.nxs.h5"), data_server.path_to("REF_M_38199.nxs.h5")]
         )
         assert "values for log DANGLE that differ above tolerance 0.01" in message
+
+    @pytest.mark.parametrize(
+        "error_type, error_msg",
+        [
+            (NormalizeToUnityQCutoffError, "Error in normalize to unity when stitching"),
+            (RuntimeError, "Error in stitching"),
+            (ValueError, "Error in stitching"),
+        ],
+    )
+    def test_stitch_reflectivity_errors(self, mocker, error_type, error_msg):
+        """Test that stitch_reflectivity catches errors in stitching and calls report_message"""
+        # Mock exception raised in stitch_data_sets
+        mocker.patch("reflectivity_ui.interfaces.data_manager.DataManager.stitch_data_sets", side_effect=error_type)
+        # Mock call to function report_message
+        mock_report_message = mocker.patch(
+            "reflectivity_ui.interfaces.event_handlers.main_handler.MainHandler.report_message"
+        )
+        self.handler.stitch_reflectivity()
+        assert error_msg in mock_report_message.call_args[0][0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves [Defect 2509: QuickNXS show error when normalize fails due to no data below Q cutoff](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2509)

The option "Normalize to unity when stitching" can erroneously produce a scaling factor of 1 instead of scaling the specular ridge (lowest Q part of the reflectivity curve) intensity to 1. This happens when the parameter "Critical Q cutoff" has a value below the lowest Q value in the lowest reflectivity curve.

Description of changes:
Raise an exception in `smart_stitch_reflectivity` if "Normalize to unity when stitchign" fails because there is no data below the "Critical Q cutoff". Catch the exception in `MainHandler.stitch_reflectivity` and display a pop up error message to the user.

To test:
- Load some data in QuickNXS
- Set the checkbox "Normalize to unity when stitching" as checked
- Set the parameter "Critical Q cutoff" to a value that is lower than the lowest Q value in the reflectivity curve
- Press the button for stitching "Scale total reflection ..."
- Check that a pop up error is displayed:
![image](https://github.com/neutrons/reflectivity_ui/assets/6989921/21992efb-dc5f-4710-a815-e053271e8859)

