### PR TITLE
Small fixes to make all data visible in reduction table

### DIFF
--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -869,7 +869,7 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="1">
+            <item row="7" column="1" colspan="2">
              <widget class="QLabel" name="label_29">
               <property name="text">
                <string>Critical Q cutoff</string>
@@ -879,7 +879,7 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="2">
+            <item row="7" column="3">
              <widget class="QDoubleSpinBox" name="normalization_q_cutoff_spinbox">
               <property name="toolTip">
                <string>Q-value below which the reflectivity should be 1.</string>
@@ -957,7 +957,7 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="2">
+            <item row="10" column="3">
              <widget class="QSpinBox" name="polynomial_stitching_degree_spinbox">
               <property name="value">
                <number>3</number>
@@ -971,7 +971,7 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
+            <item row="10" column="1" colspan="2">
              <widget class="QLabel" name="label_56">
               <property name="text">
                <string>Polynomial degree</string>
@@ -981,7 +981,7 @@
               </property>
              </widget>
             </item>
-            <item row="11" column="1">
+            <item row="11" column="1" colspan="2">
              <widget class="QLabel" name="label_57">
               <property name="text">
                <string>Points outside overlap</string>
@@ -991,7 +991,7 @@
               </property>
              </widget>
             </item>
-            <item row="11" column="2">
+            <item row="11" column="3">
              <widget class="QSpinBox" name="polynomial_stitching_points_spinbox">
               <property name="value">
                <number>3</number>
@@ -2651,7 +2651,7 @@
                        <bool>true</bool>
                       </attribute>
                       <attribute name="horizontalHeaderDefaultSectionSize">
-                       <number>50</number>
+                       <number>70</number>
                       </attribute>
                       <attribute name="horizontalHeaderMinimumSectionSize">
                        <number>20</number>


### PR DESCRIPTION
Resolves [Defect 2613: QuickNXS fix too small column widths](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2613)

Adjust the UI:

- Increase column size in reduction table to make the data fit
- Reposition elements in the tab "Reflectivity Extraction (Advanced)" to remove the need for a scroll bar

Before:

![QuickNXS main window before](https://github.com/neutrons/reflectivity_ui/assets/6989921/df81b331-d711-4d74-a90b-7501792b7a0b)


After:

![QuickNXS main window after](https://github.com/neutrons/reflectivity_ui/assets/6989921/7f6326c2-7afa-407d-a76e-6375f10351de)
