### PR TITLE
replace SANGLE with SampleAngle

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/instrument.py
+++ b/reflectivity_ui/interfaces/data_handling/instrument.py
@@ -268,7 +268,10 @@ class Instrument(object):
             data_object.slit3_width = data["S3HWidth"].value[0]
         data_object.huber_x = data["HuberX"].getStatistics().mean
 
-        data_object.sangle = data["SANGLE"].getStatistics().mean
+        if "SampleAngle" in data:
+            data_object.sangle = data["SampleAngle"].getStatistics().mean
+        else:
+            data_object.sangle = data["SANGLE"].getStatistics().mean
 
         data_object.dist_sam_det = data["SampleDetDis"].value[0] * 1e-3
         data_object.dist_mod_det = data["ModeratorSamDis"].value[0] * 1e-3 + data_object.dist_sam_det

--- a/reflectivity_ui/ui/ui_main_window-edit.ui
+++ b/reflectivity_ui/ui/ui_main_window-edit.ui
@@ -767,7 +767,7 @@
                </size>
               </property>
               <property name="text">
-               <string>SANGLE</string>
+               <string>SampleAngle</string>
               </property>
               <property name="checked">
                <bool>true</bool>
@@ -2358,7 +2358,7 @@
                  <string>Sample angle read from file</string>
                 </property>
                 <property name="text">
-                 <string>SANGLE</string>
+                 <string>SampleAngle</string>
                 </property>
                 <property name="textInteractionFlags">
                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -2399,7 +2399,7 @@
                  <string>Sample angle calculated from 2Θ and X-center position</string>
                 </property>
                 <property name="text">
-                 <string>SANGLE-calc</string>
+                 <string>SampleAngle-calc</string>
                 </property>
                 <property name="textInteractionFlags">
                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -806,7 +806,7 @@
                </size>
               </property>
               <property name="text">
-               <string>SANGLE</string>
+               <string>SampleAngle</string>
               </property>
               <property name="checked">
                <bool>true</bool>
@@ -1819,7 +1819,7 @@
                          <string>Sample angle read from file</string>
                         </property>
                         <property name="text">
-                         <string>SANGLE</string>
+                         <string>SampleAngle</string>
                         </property>
                         <property name="textInteractionFlags">
                          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -1872,7 +1872,7 @@
                          <string>Sample angle calculated from 2Θ and X-center position</string>
                         </property>
                         <property name="text">
-                         <string>SANGLE-calc</string>
+                         <string>SampleAngle-calc</string>
                         </property>
                         <property name="textInteractionFlags">
                          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
The instrument has a couple of ways to define the sample angle. The newer PV `SampleAngle` should replace `SANGLE` in the data reduction.

Here's a PR that replace it in the UI only, so that the values that we reported are correct.
Before merging, we would need to update the `MagnetismReflectometryReduction` algorithm to do the same. We can keep the same parameters, but it should pull `SampleAngle` rather than `SANGLE`.