### PR TITLE
update mantid version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - versioningit
 
   run:
-    - mantid>=6.7.20230822,<6.8
+    - mantid=6.8
     - matplotlib
     - qtpy
     - qt>=5.12,<6

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 name: quicknxs
 channels:
-    - mantid/label/nightly
+    - mantid/label/main
     - conda-forge
     - default
 dependencies:
-- mantidworkbench>=6.7.20230822,<6.8
+- mantidworkbench=6.8
 - anaconda-client
 - boa
 - build


### PR DESCRIPTION
There's no more mantidworkbench 6.7.*