### PR TITLE
Make messages in status bar disappear after 10 seconds

### DIFF
--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -8,6 +8,7 @@
 
 # package imports
 from reflectivity_ui.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
+from .status_bar_handler import StatusBarHandler
 from ..configuration import Configuration
 from .progress_reporter import ProgressReporter
 from .widgets import AcceptRejectDialog
@@ -59,14 +60,11 @@ class MainHandler(object):
         self.progress_bar.setMaximumSize(140, 100)
         self.ui.statusbar.addPermanentWidget(self.progress_bar)
 
-        self.status_message = QtWidgets.QLabel("")
-        self.status_message.setMinimumWidth(1000)
-        self.status_message.setMargin(5)
-        self.ui.statusbar.insertWidget(0, self.status_message)
+        self.status_bar_handler = StatusBarHandler(self.ui.statusbar)
 
     def new_progress_reporter(self):
         """Return a progress reporter"""
-        return ProgressReporter(progress_bar=self.progress_bar, status_bar=self.status_message)
+        return ProgressReporter(progress_bar=self.progress_bar, status_bar=self.status_bar_handler)
 
     def empty_cache(self):
         """
@@ -123,7 +121,7 @@ class MainHandler(object):
         self.main_window.auto_change_active = True
         try:
             self.report_message("Loading file(s) %s" % file_path)
-            prog = ProgressReporter(progress_bar=self.progress_bar, status_bar=self.status_message)
+            prog = ProgressReporter(progress_bar=self.progress_bar, status_bar=self.status_bar_handler)
             configuration = self.get_configuration()
             self._data_manager.load(file_path, configuration, force=force, progress=prog)
             self.report_message("Loaded file(s) %s" % self._data_manager.current_file_name)
@@ -1390,7 +1388,7 @@ class MainHandler(object):
         :param bool pop_up: if True, a dialog will pop up
         :param bool is_error: if True, the message is logged on the error channel
         """
-        self.status_message.setText(message)
+        self.status_bar_handler.show_message(message)
         if is_error:
             logging.error(message)
             if detailed_message is not None:

--- a/reflectivity_ui/interfaces/event_handlers/progress_reporter.py
+++ b/reflectivity_ui/interfaces/event_handlers/progress_reporter.py
@@ -78,7 +78,7 @@ class ProgressReporter(object):
             self.progress_bar.setValue(_value)
 
         if message and self.status_bar:
-            self.status_bar.setText(message)
+            self.status_bar.show_message(message)
 
     def create_sub_task(self, max_value):
         """

--- a/reflectivity_ui/interfaces/event_handlers/status_bar_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/status_bar_handler.py
@@ -1,0 +1,26 @@
+from PyQt5.QtWidgets import QStatusBar
+
+
+class StatusBarHandler(object):
+    """Status bar handler class"""
+
+    def __init__(self, status_bar: QStatusBar):
+        """
+        Initialize the status message handler.
+
+        Parameters
+        ----------
+        :param status_bar: The status bar to show messages in
+        """
+        self.status_bar = status_bar
+
+    def show_message(self, message: str, msecs: int = 10000):
+        """
+        Show a message in the status bar.
+
+        Parameters
+        ----------
+        :param message: The message to show
+        :param msecs: The duration of the message in milliseconds
+        """
+        self.status_bar.showMessage(message, msecs=msecs)

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -955,6 +955,9 @@
               <property name="text">
                <string>Global fit when stitching</string>
               </property>
+              <property name="toolTip">
+               <string>Perform stitching fit using all cross-sections</string>
+              </property>
              </widget>
             </item>
             <item row="10" column="3">
@@ -968,6 +971,9 @@
              <widget class="QCheckBox" name="polynomial_stitching_checkbox">
               <property name="text">
                <string>Polynomial fit when stitching</string>
+              </property>
+              <property name="toolTip">
+               <string>Use polynomial function to determine scaling factors</string>
               </property>
              </widget>
             </item>
@@ -1060,9 +1066,6 @@
              <widget class="QCheckBox" name="fit_within_roi_checkbox">
               <property name="toolTip">
                <string>Once the reflected peak ROI is selected, you can try to fine tune this ROI by fitting for a peak within that region and updating the ROI according to the location found. Check the following box if you want to find a peak within the ROI and redefine the ROI afterwards.</string>
-              </property>
-              <property name="statusTip">
-               <string/>
               </property>
               <property name="text">
                <string>Fit peak within ROI</string>
@@ -2320,9 +2323,6 @@
                     <property name="toolTip">
                      <string>Direct beam indicator to let you know whether the application thinks this might be a direct beam.</string>
                     </property>
-                    <property name="statusTip">
-                     <string>Direct beam indicator to let you know whether the application thinks this might be a direct beam.</string>
-                    </property>
                     <property name="text">
                      <string/>
                     </property>
@@ -3237,9 +3237,6 @@
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Recalculate the offspecular data</string>
-             </property>
-             <property name="statusTip">
               <string>Recalculate the offspecular data</string>
              </property>
              <property name="text">
@@ -5042,9 +5039,6 @@
     <string>Use common ranges</string>
    </property>
    <property name="toolTip">
-    <string>Apply identical ranges to all cross-sections</string>
-   </property>
-   <property name="statusTip">
     <string>Apply identical ranges to all cross-sections</string>
    </property>
   </action>

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
 import os
 
-SNS_REFM_MOUNTED = os.path.isdir("/SNS/REF_M/")
+SNS_REFM_MOUNTED = os.path.isdir("/SNS/REF_M/shared/")
 ONE_SECOND = 1000  # ms, a wait time for qtbot

--- a/test/ui/test_status_bar.py
+++ b/test/ui/test_status_bar.py
@@ -1,0 +1,33 @@
+import pytest
+
+from reflectivity_ui.interfaces.event_handlers.progress_reporter import ProgressReporter
+from reflectivity_ui.interfaces.main_window import MainWindow
+
+
+class TestStatusBar:
+    def test_report_message(self, qtbot):
+        """Test that function report_message updates the status bar message"""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        assert window_main.ui.statusbar.currentMessage() == ""
+        # Test that report_message updates the status bar message
+        window_main.file_handler.report_message("Test report_message")
+        assert window_main.ui.statusbar.currentMessage() == "Test report_message"
+        window_main.file_handler.report_message("Different message")
+        assert window_main.ui.statusbar.currentMessage() == "Different message"
+
+    def test_progress_reporter(self, qtbot):
+        """Test that the progress reporter updates the status bar message"""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        progress_reporter = ProgressReporter(
+            100, None, window_main.file_handler.status_bar_handler, window_main.file_handler.progress_bar
+        )
+        assert window_main.ui.statusbar.currentMessage() == ""
+        # Test that progress reporter update function updates the status bar message
+        progress_reporter.update("Test progress reporter")
+        assert window_main.ui.statusbar.currentMessage() == "Test progress reporter"
+        # Test that progress reporter set_value function updates the status bar
+        progress_reporter.set_value(2, "Loaded file", out_of=10)
+        assert window_main.ui.statusbar.currentMessage() == "Loaded file"
+        assert window_main.file_handler.progress_bar.value() == 20


### PR DESCRIPTION
Use the `QStatusBar` method `showMessage` to make status messages temporary with a timeout. Encapsulate the updating in a class `StatusBarHandler` to not access the raw UI element in several places (probably making things messier in the process).

Resolves
[Defect 2691: [Quicknxs] Remove error message after success](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2691)
[Defect 2892: [Quicknxs] tooltips to "Global fit" and "Polynomial fit" check boxes](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2892).

To test

- Perform an action that generates a message in the status bar. Verify that the message is visible for about 10 seconds. (One way is to set "Critical Q cutoff" to a value lower than the smallest Q-value in the reflectivity curve and then press the stitching button.)
- Verify that the tool tips appear when hovering over the options "Global fit when stitching" and "Polynomial fit when stitching".