### PR TITLE
Export direct beam data

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -93,10 +93,8 @@ def getIxyt(nxs_data):
     for x in range(sz_x_axis):
         for y in range(sz_y_axis):
             _index = int(sz_y_axis * x + y)
-            _tmp_data = nxs_data.readY(_index)[:]
-            _y_axis[x, y, :] = _tmp_data
-            _tmp_error = nxs_data.readE(_index)[:]
-            _y_error_axis[x, y, :] = _tmp_error
+            _y_axis[x, y, :] = nxs_data.readY(_index)[:]
+            _y_error_axis[x, y, :] = nxs_data.readE(_index)[:]
 
     return _y_axis, _y_error_axis
 

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -88,15 +88,17 @@ def getIxyt(nxs_data):
     sz_x_axis = int(nxs_data.getInstrument().getNumberParameter("number-of-x-pixels")[0])  # 304
 
     _y_axis = np.zeros((sz_x_axis, sz_y_axis, nbr_tof - 1))
-    # _y_error_axis = np.zeros((sz_x_axis, sz_y_axis, nbr_tof-1))
+    _y_error_axis = np.zeros((sz_x_axis, sz_y_axis, nbr_tof - 1))
 
     for x in range(sz_x_axis):
         for y in range(sz_y_axis):
             _index = int(sz_y_axis * x + y)
             _tmp_data = nxs_data.readY(_index)[:]
             _y_axis[x, y, :] = _tmp_data
+            _tmp_error = nxs_data.readE(_index)[:]
+            _y_error_axis[x, y, :] = _tmp_error
 
-    return _y_axis
+    return _y_axis, _y_error_axis
 
 
 class NexusData(object):
@@ -478,6 +480,7 @@ class CrossSectionData(object):
         self.data = None
         self.xydata = None
         self.xtofdata = None
+        self.raw_error = None
 
         self.meta_data_roi_peak = None
         self.meta_data_roi_bck = None
@@ -725,13 +728,14 @@ class CrossSectionData(object):
             t_0 = time.time()
             binning_ws = api.CreateWorkspace(DataX=self.tof_edges, DataY=np.zeros(len(self.tof_edges) - 1))
             data_rebinned = api.RebinToWorkspace(WorkspaceToRebin=workspace, WorkspaceToMatch=binning_ws)
-            Ixyt = getIxyt(data_rebinned)
+            Ixyt, Ixyt_error = getIxyt(data_rebinned)
 
             # Create projections for the 2D datasets
             Ixy = Ixyt.sum(axis=2)
             Ixt = Ixyt.sum(axis=1)
             # Store the data
             self.data = Ixyt.astype(float)  # 3D dataset
+            self.raw_error = Ixyt_error.astype(float)  # 3D dataset
             self.xydata = Ixy.transpose().astype(float)  # 2D dataset
             self.xtofdata = Ixt.astype(float)  # 2D dataset
             logging.info("Plot data generated: %s sec", time.time() - t_0)
@@ -784,6 +788,59 @@ class CrossSectionData(object):
         bck = self.get_background_vs_TOF()
 
         return (summed_raw / math.fabs(size_roi) - bck) / self.proton_charge
+
+    def get_tof_counts_table(self):
+        """
+        Get a table of TOF vs counts in the region-of-interest (ROI)
+
+        The table columns are:
+        - TOF
+        - wavelength
+        - counts normalized by proton charge
+        - error in counts normalized by proton charge
+        - counts
+        - error in counts
+        - size of the ROI
+        """
+        self.prepare_plot_data()
+        # Calculate ROI intensities and normalize by number of points
+        data_roi = self.data[
+            self.configuration.peak_roi[0] : self.configuration.peak_roi[1],
+            self.configuration.low_res_roi[0] : self.configuration.low_res_roi[1],
+            :,
+        ]
+        counts_roi = data_roi.sum(axis=(0, 1))
+        raw_error_roi = self.raw_error[
+            self.configuration.peak_roi[0] : self.configuration.peak_roi[1],
+            self.configuration.low_res_roi[0] : self.configuration.low_res_roi[1],
+            :,
+        ]
+        counts_roi_error = np.linalg.norm(raw_error_roi, axis=(0, 1))  # square root of sum of squares
+        if self.proton_charge > 0.0:
+            counts_roi_normalized = counts_roi / self.proton_charge
+            counts_roi_normalized_error = counts_roi_error / self.proton_charge
+        else:
+            counts_roi_normalized = counts_roi
+            counts_roi_normalized_error = counts_roi_error
+        size_roi = len(counts_roi) * [
+            float(
+                (self.configuration.low_res_roi[1] - self.configuration.low_res_roi[0])
+                * (self.configuration.peak_roi[1] - self.configuration.peak_roi[0])
+            )
+        ]
+        data_table = np.vstack(
+            (
+                self.tof,
+                self.wavelength,
+                counts_roi_normalized,
+                counts_roi_normalized_error,
+                counts_roi,
+                counts_roi_error,
+                size_roi,
+            )
+        ).T
+        header = "tof wavelength counts_normalized counts_normalized_error counts counts_error size_roi"
+        return data_table, header
 
     def get_background_vs_TOF(self):
         """

--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -7,12 +7,13 @@
 import numpy as np
 
 # package imports
+from reflectivity_ui.interfaces.configuration import Configuration
 from reflectivity_ui.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
-from .status_bar_handler import StatusBarHandler
-from ..configuration import Configuration
-from .progress_reporter import ProgressReporter
-from .widgets import AcceptRejectDialog
+from reflectivity_ui.interfaces.data_handling.data_set import NexusData, CrossSectionData
 from reflectivity_ui.interfaces.data_handling.filepath import FilePath, RunNumbers
+from reflectivity_ui.interfaces.event_handlers.progress_reporter import ProgressReporter
+from reflectivity_ui.interfaces.event_handlers.status_bar_handler import StatusBarHandler
+from reflectivity_ui.interfaces.event_handlers.widgets import AcceptRejectDialog
 from reflectivity_ui.config import Settings
 
 # 3rd-party imports
@@ -27,8 +28,6 @@ import os
 import sys
 import time
 import traceback
-
-from ..data_handling.data_set import NexusData, CrossSectionData
 
 
 class MainHandler(object):
@@ -1022,7 +1021,7 @@ class MainHandler(object):
             # check if file exists
             if os.path.isfile(filepath):
                 if not self.ask_question(f"Overwrite existing file {filename}?"):
-                    return
+                    continue
             # save file
             cross_section = nexus_data.cross_sections[xs]
             data_to_save, header = cross_section.get_tof_counts_table()

--- a/reflectivity_ui/interfaces/main_window.py
+++ b/reflectivity_ui/interfaces/main_window.py
@@ -5,7 +5,6 @@ r"""
     Main application window
 """
 
-
 # package imports
 from .data_manager import DataManager
 from .plotting import PlotManager
@@ -47,6 +46,7 @@ class MainWindow(QtWidgets.QMainWindow):
         QtWidgets.QMainWindow.__init__(self)
 
         # Initialize the UI widgets
+        self.reduction_table_menu = None
         self.ui = load_ui("ui_main_window.ui", baseinstance=self)
         version = reflectivity_ui.__version__ if reflectivity_ui.__version__.lower() != "unknown" else ""
         self.setWindowTitle(f"QuickNXS Magnetic Reflectivity {version}")
@@ -303,6 +303,20 @@ class MainWindow(QtWidgets.QMainWindow):
             self.data_manager.set_active_data_from_reduction_list(row)
             self.file_loaded()
             self.file_handler.active_data_changed()
+
+    def reduction_table_right_click(self, pos):
+        """
+        Handle right-click on the reduction table.
+        :param QPoint pos: mouse position
+        """
+        self.file_handler.reduction_table_right_click(pos, True)
+
+    def direct_beam_table_right_click(self, pos):
+        """
+        Handle right-click on the direct beam table.
+        :param QPoint pos: mouse position
+        """
+        self.file_handler.reduction_table_right_click(pos, False)
 
     def direct_beam_cell_activated(self, row, col):
         """

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -2644,6 +2644,9 @@
                       <property name="rowCount">
                        <number>0</number>
                       </property>
+                      <property name="contextMenuPolicy">
+                       <enum>Qt::CustomContextMenu</enum>
+                      </property>
                       <attribute name="horizontalHeaderVisible">
                        <bool>true</bool>
                       </attribute>
@@ -2809,6 +2812,9 @@
                       </property>
                       <property name="editTriggers">
                        <set>QAbstractItemView::NoEditTriggers</set>
+                      </property>
+                      <property name="contextMenuPolicy">
+                       <enum>Qt::CustomContextMenu</enum>
                       </property>
                       <attribute name="horizontalHeaderCascadingSectionResizes">
                        <bool>true</bool>
@@ -6440,6 +6446,38 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>reductionTable</sender>
+   <signal>customContextMenuRequested(QPoint)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>reduction_table_right_click(QPoint)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1508</x>
+     <y>1348</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>778</x>
+     <y>551</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>normalizeTable</sender>
+   <signal>customContextMenuRequested(QPoint)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>direct_beam_table_right_click(QPoint)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1508</x>
+     <y>1348</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>778</x>
+     <y>551</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>file_open_dialog()</slot>
@@ -6490,5 +6528,6 @@
   <slot>hide_sidebar()</slot>
   <slot>hide_run_data()</slot>
   <slot>hide_data_table()</slot>
+  <slot>reduction_table_right_click()</slot>
  </slots>
 </ui>

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_data_set.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_data_set.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from reflectivity_ui.interfaces.configuration import Configuration
+from reflectivity_ui.interfaces.data_handling.data_set import CrossSectionData
+
+
+def _get_cross_section_data():
+    """Get instance of CrossSectionData for testing"""
+    config = Configuration()
+    config.peak_position = 3
+    config.peak_width = 1
+    config.low_res_position = 2
+    config.low_res_width = 2
+    xs = CrossSectionData("On_Off", config)
+    pixel_counts = [[0, 0, 1, 1, 0, 0], [0, 1, 3, 4, 1, 0], [0, 1, 2, 4, 1, 0], [0, 0, 1, 1, 0, 0]]
+    pixel_counts = np.array(pixel_counts).astype(float)
+    xs.data = np.array([pixel_counts, pixel_counts, pixel_counts]).T
+    xs.raw_error = np.ones_like(xs.data)
+    xs.tof_edges = np.array([0.1, 0.2, 0.3, 0.4])
+    xs.proton_charge = 8.03e5
+    xs.dist_mod_det = 2.96
+    return xs
+
+
+class TestCrossSectionData(object):
+    def test_r_scaling_factor(self):
+        config = Configuration()
+        xs = CrossSectionData("On_Off", config)
+        xs._r = 0.8
+        xs._dr = 0.1
+        setattr(xs.configuration, "scaling_factor", 0.35)
+        setattr(xs.configuration, "scaling_error", 0.01)
+
+        assert xs.r == pytest.approx(0.28, rel=1e-6)
+        assert xs.dr == pytest.approx(0.035902646, rel=1e-6)
+
+    def test_get_tof_counts_table(self, mocker):
+        """Test of method get_tof_counts_table"""
+        mocker.patch("reflectivity_ui.interfaces.data_handling.data_set.CrossSectionData.prepare_plot_data")
+        rel_tol = 1e-6
+        xs = _get_cross_section_data()
+        data_table, header = xs.get_tof_counts_table()
+        assert len(data_table) == 3
+        assert data_table[0][0] == pytest.approx(0.15, rel_tol)  # tof
+        assert data_table[0][1] == pytest.approx(2.0046381e-4, rel_tol)  # wavelength
+        assert data_table[0][2] == pytest.approx(13.0 / xs.proton_charge, rel_tol)  # counts normalized
+        assert data_table[0][3] == pytest.approx(2.0 / xs.proton_charge, rel_tol)  # counts normalized error
+        assert data_table[0][4] == pytest.approx(13.0, rel_tol)  # counts
+        assert data_table[0][5] == pytest.approx(2.0, rel_tol)  # counts error
+        assert data_table[0][6] == 4  # size of ROI
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
@@ -99,12 +99,18 @@ def test_save_run_data(tmp_path, qtbot, mocker):
         "reflectivity_ui.interfaces.data_handling.data_set.CrossSectionData.get_tof_counts_table",
         return_value=(np.ones((5, 5)), header),
     )
+    mocker.patch(
+        "reflectivity_ui.interfaces.event_handlers.main_handler.MainHandler.ask_question", side_effect=[False, True]
+    )
 
     main_window = MainWindow()
     handler = MainHandler(main_window)
     qtbot.addWidget(main_window)
 
     nexus_data = _get_nexus_data()
+    # test save files
+    handler.save_run_data(nexus_data)
+    # test save and overwrite existing files
     handler.save_run_data(nexus_data)
 
     for xs in nexus_data.cross_sections.keys():


### PR DESCRIPTION
# Short description of the changes:
Add right-click option "Export data" to reduction table and direct beam table to save text file with:

- TOF
- wavelength
- counts normalized by proton charge
- error in counts normalized by proton charge
- counts
- error in counts
- size of ROI

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [x] I have verified the proposed changes
- [x] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [x] All the tests are passing
- [x] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Open QuickNXS. Load a reduced data file.
1. Test right-click -> "Export data" on one run in the reduction table and verify that a `.dat` file with counts data is saved.
2. Test right-click -> "Export data" on one run in the direct beam table and verify that a `.dat` file with counts data is saved.
3. Test that QuickNXS warns before overwriting a previous file with the same name.

# References
[Story 2259: [QUICKNXS] Add a way to export direct beam data](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2259)