### PR TITLE
Always output ASCII

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/processing_workflow.py
+++ b/reflectivity_ui/interfaces/data_handling/processing_workflow.py
@@ -33,7 +33,6 @@ DEFAULT_OPTIONS = dict(
     format_genx=False,
     format_matlab=False,
     format_mantid=True,
-    format_multi=True,
     format_numpy=False,
     format_5cols=False,
     output_sample_size=10,
@@ -219,9 +218,8 @@ class ProcessingWorkflow(object):
         output_data = self.get_output_data()
 
         # QuickNXS format
-        if self.output_options["format_multi"]:
-            output_file_base = self.get_file_name(run_list)
-            self.write_quicknxs(output_data, output_file_base)
+        output_file_base = self.get_file_name(run_list)
+        self.write_quicknxs(output_data, output_file_base)
 
         # Numpy arrays
         if self.output_options["format_numpy"]:

--- a/reflectivity_ui/interfaces/reduction_dialog.py
+++ b/reflectivity_ui/interfaces/reduction_dialog.py
@@ -36,7 +36,6 @@ class ReductionDialog(QtWidgets.QDialog):
         # Formats
         self.ui.genx.setChecked(self._verify_true("format_genx", False))
         self.ui.matlab.setChecked(self._verify_true("format_matlab", False))
-        self.ui.multiAscii.setChecked(self._verify_true("format_multi", False))
         self.ui.numpy.setChecked(self._verify_true("format_numpy", False))
         self.ui.mantid_script_checkbox.setChecked(self._verify_true("format_mantid", False))
         self.ui.five_cols_checkbox.setChecked(self._verify_true("format_5cols", True))
@@ -78,7 +77,6 @@ class ReductionDialog(QtWidgets.QDialog):
             format_genx=self.ui.genx.isChecked(),
             format_matlab=self.ui.matlab.isChecked(),
             format_mantid=self.ui.mantid_script_checkbox.isChecked(),
-            format_multi=self.ui.multiAscii.isChecked(),
             format_numpy=self.ui.numpy.isChecked(),
             format_5cols=self.ui.five_cols_checkbox.isChecked(),
             output_directory=self.ui.directoryEntry.text(),
@@ -119,7 +117,6 @@ class ReductionDialog(QtWidgets.QDialog):
 
         self.settings.setValue("format_genx", self.ui.genx.isChecked())
         self.settings.setValue("format_matlab", self.ui.matlab.isChecked())
-        self.settings.setValue("format_multi", self.ui.multiAscii.isChecked())
         self.settings.setValue("format_numpy", self.ui.numpy.isChecked())
         self.settings.setValue("format_mantid", self.ui.mantid_script_checkbox.isChecked())
         self.settings.setValue("format_5cols", self.ui.five_cols_checkbox.isChecked())

--- a/reflectivity_ui/ui/ui_reduce_dialog.ui
+++ b/reflectivity_ui/ui/ui_reduce_dialog.ui
@@ -106,21 +106,9 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QCheckBox" name="multiAscii">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="mouseTracking">
-             <bool>true</bool>
-            </property>
+           <widget class="QLabel" name="label_7">
             <property name="text">
              <string>ASCII</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -251,6 +239,19 @@
         <number>0</number>
        </property>
        <item>
+        <widget class="QLabel" name="label_8">
+         <property name="styleSheet">
+          <string notr="true">color: red;</string>
+         </property>
+         <property name="text">
+          <string>Email can only be sent to @ornl addresses.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QGridLayout" name="gridLayout_3">
          <item row="0" column="2">
           <widget class="QCheckBox" name="emailZIPData">
@@ -376,7 +377,6 @@
   <tabstop>exportOffSpecular</tabstop>
   <tabstop>exportOffSpecularSmoothed</tabstop>
   <tabstop>exportGISANS</tabstop>
-  <tabstop>multiAscii</tabstop>
   <tabstop>toolButton</tabstop>
   <tabstop>tabWidget</tabstop>
  </tabstops>


### PR DESCRIPTION
Remove option for ASCII output, it should always be produced. Also add a message about email only working for ornl.gov.

The screens should now look like this.

![2024-03-21-155356_400x512_scrot](https://github.com/neutrons/reflectivity_ui/assets/5595210/fec4b06f-ca46-449d-9259-5ef92d90ad14)
![2024-03-21-155412_400x512_scrot](https://github.com/neutrons/reflectivity_ui/assets/5595210/213b4774-f470-4358-b6c7-3aa4eca5cb2d)



# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
