### PR TITLE
Recalculate and replot reflectivity when global config is changed

### DIFF
--- a/docs/api/reflectivity_ui.interfaces.event_handlers.rst
+++ b/docs/api/reflectivity_ui.interfaces.event_handlers.rst
@@ -10,6 +10,14 @@ reflectivity\_ui.interfaces.event\_handlers package
 Submodules
 ----------
 
+reflectivity\_ui.interfaces.event\_handlers.configuration\_handler module
+-------------------------------------------------------------------------
+
+.. automodule:: reflectivity_ui.interfaces.event_handlers.configuration_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 reflectivity\_ui.interfaces.event\_handlers.main\_handler module
 ----------------------------------------------------------------
 

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -452,6 +452,16 @@ class DataManager(object):
                 return False
         return True
 
+    def reduce_spec(self):
+        """
+        Calculate reflectivity for all runs in the reduction list
+        """
+        for nexus_data in self.reduction_list:
+            try:
+                self.calculate_reflectivity(nexus_data=nexus_data)
+            except:
+                logging.error("Could not compute reflectivity for %s\n  %s", nexus_data.number, sys.exc_info()[1])
+
     def reduce_offspec(self, progress=None):
         """
         Since the specular reflectivity is prominently displayed, it is updated as

--- a/reflectivity_ui/interfaces/event_handlers/configuration_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/configuration_handler.py
@@ -9,13 +9,6 @@ from PyQt5.QtWidgets import QSpinBox, QCheckBox, QDoubleSpinBox, QWidget
 from dataclasses import dataclass
 
 
-@dataclass
-class ConfigWidget:
-    widget_name: str
-    config_name: str
-    recalc_reflectivity: bool = False
-
-
 class ConfigurationHandler:
     """
     Handles events upon changes in the configuration
@@ -41,10 +34,10 @@ class ConfigurationHandler:
 
         Parameters
         ----------
+        qwidget: QWidget
+            UI widget
         config_name: str
             Name of the Configuration variable to update
-        is_checkbox: bool
-            True if the widget type is QCheckBox
         """
 
         def config_setter():
@@ -66,6 +59,23 @@ class ConfigurationHandler:
 
     def connect_config_events(self):
         """Connect configuration widget events"""
+
+        @dataclass
+        class ConfigWidget:
+            """Class to help connect UI configuration widgets to events
+
+            Holds widget name and the `Configuration` class variable it represents, as well
+            as information about any events the widget triggers
+
+            Args:
+                widget_name (str): name of a QWidget
+                config_name (str): name of a `Configuration` class variable
+                recalc_reflectivity (bool): if True, trigger global reflectivity recalculation
+            """
+
+            widget_name: str
+            config_name: str
+            recalc_reflectivity: bool = False
 
         config_widgets = [
             ConfigWidget("final_rebin_checkbox", "do_final_rebin", recalc_reflectivity=True),

--- a/reflectivity_ui/interfaces/main_window.py
+++ b/reflectivity_ui/interfaces/main_window.py
@@ -292,6 +292,9 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         Perform action upon change in global reflectivity configuration.
         """
+        if self.auto_change_active:
+            return
+
         self.data_manager.reduce_spec()
         self.initiate_reflectivity_plot.emit(True)
         self.update_specular_viewer.emit()

--- a/reflectivity_ui/interfaces/main_window.py
+++ b/reflectivity_ui/interfaces/main_window.py
@@ -288,6 +288,14 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.plot_manager.plot_refl()
                 self.update_specular_viewer.emit()
 
+    def global_reflectivity_config_changed(self):
+        """
+        Perform action upon change in global reflectivity configuration.
+        """
+        self.data_manager.reduce_spec()
+        self.initiate_reflectivity_plot.emit(True)
+        self.update_specular_viewer.emit()
+
     def reductionTableChanged(self, item):
         """
         Perform action upon change in data reduction list.

--- a/reflectivity_ui/ui/ui_main_window.ui
+++ b/reflectivity_ui/ui/ui_main_window.ui
@@ -5695,22 +5695,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>fanReflectivity</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeRegionValues()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>168</x>
-     <y>727</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>85</x>
-     <y>839</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>normalizeXTof</sender>
    <signal>stateChanged(int)</signal>
    <receiver>MainWindow</receiver>
@@ -6266,38 +6250,6 @@
     </hint>
     <hint type="destinationlabel">
      <x>921</x>
-     <y>503</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>final_rebin_checkbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeRegionValues()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>58</x>
-     <y>753</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>934</x>
-     <y>503</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>q_rebin_spinbox</sender>
-   <signal>editingFinished()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeRegionValues()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>315</x>
-     <y>757</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>934</x>
      <y>503</y>
     </hint>
    </hints>

--- a/test/ui/test_reflectivity_extraction_global.py
+++ b/test/ui/test_reflectivity_extraction_global.py
@@ -82,7 +82,8 @@ def test_global_spinboxes(qtbot, widget, config_param, gold_value):
     qtbot.addWidget(main_window)
     _initialize_test_data(main_window)
 
-    getattr(main_window.ui, widget).setValue(gold_value)
+    qwidget = getattr(main_window.ui, widget)
+    ui_utilities.setValue(qwidget, gold_value)
     _assert_configuration_float_value(main_window, config_param, gold_value)
 
 

--- a/test/ui/test_reflectivity_extraction_global.py
+++ b/test/ui/test_reflectivity_extraction_global.py
@@ -88,13 +88,15 @@ def test_global_spinboxes(qtbot, widget, config_param, gold_value):
 
 @pytest.mark.datarepo
 def test_reflectivity_recalculated_on_config_change(mocker, qtbot):
-    '''Test that changing global binning configuration triggers recalculating reflectivity for all runs'''
+    """Test that changing global binning configuration triggers recalculating reflectivity for all runs"""
     main_window = MainWindow()
     qtbot.addWidget(main_window)
 
     # use mock and wrap to call function while also getting call count
     data_manager = main_window.data_manager
-    mock_calculate_reflectivity = mocker.patch.object(data_manager, 'calculate_reflectivity', wraps=data_manager.calculate_reflectivity)
+    mock_calculate_reflectivity = mocker.patch.object(
+        data_manager, "calculate_reflectivity", wraps=data_manager.calculate_reflectivity
+    )
 
     # add two runs to the reduction table
     ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
@@ -104,7 +106,7 @@ def test_reflectivity_recalculated_on_config_change(mocker, qtbot):
     ui_utilities.set_current_file_by_run_number(main_window, 40782)
     main_window.actionAddPlot.triggered.emit()
     assert mock_calculate_reflectivity.call_count == 2
-    
+
     # check that all reflectivity curves are recalculated when global binning configuration is changed
 
     num_runs = 2

--- a/test/ui/test_reflectivity_extraction_global.py
+++ b/test/ui/test_reflectivity_extraction_global.py
@@ -2,6 +2,8 @@
 from reflectivity_ui.interfaces.configuration import Configuration
 from reflectivity_ui.interfaces.data_handling.data_set import NexusData, CrossSectionData
 from reflectivity_ui.interfaces.main_window import MainWindow
+from test.ui import ui_utilities
+
 
 # third party imports
 import pytest
@@ -82,3 +84,44 @@ def test_global_spinboxes(qtbot, widget, config_param, gold_value):
 
     getattr(main_window.ui, widget).setValue(gold_value)
     _assert_configuration_float_value(main_window, config_param, gold_value)
+
+
+@pytest.mark.datarepo
+def test_reflectivity_recalculated_on_config_change(mocker, qtbot):
+    '''Test that changing global binning configuration triggers recalculating reflectivity for all runs'''
+    main_window = MainWindow()
+    qtbot.addWidget(main_window)
+
+    # use mock and wrap to call function while also getting call count
+    data_manager = main_window.data_manager
+    mock_calculate_reflectivity = mocker.patch.object(data_manager, 'calculate_reflectivity', wraps=data_manager.calculate_reflectivity)
+
+    # add two runs to the reduction table
+    ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
+    ui_utilities.set_current_file_by_run_number(main_window, 40785)
+    main_window.actionAddPlot.triggered.emit()
+    assert mock_calculate_reflectivity.call_count == 1
+    ui_utilities.set_current_file_by_run_number(main_window, 40782)
+    main_window.actionAddPlot.triggered.emit()
+    assert mock_calculate_reflectivity.call_count == 2
+    
+    # check that all reflectivity curves are recalculated when global binning configuration is changed
+
+    num_runs = 2
+
+    # test toggling `fanReflectivity`
+    prev_call_count = mock_calculate_reflectivity.call_count
+    main_window.ui.fanReflectivity.nextCheckState()
+    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs
+
+    # test toggling `final_rebin_checkbox`
+    prev_call_count = mock_calculate_reflectivity.call_count
+    main_window.ui.final_rebin_checkbox.nextCheckState()
+    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs
+
+    # test editing `q_rebin_spinbox`
+    prev_call_count = mock_calculate_reflectivity.call_count
+    q_spinbox = main_window.ui.q_rebin_spinbox
+    q_delta = q_spinbox.singleStep() if q_spinbox.value() < 0 else -q_spinbox.singleStep()
+    ui_utilities.setValue(q_spinbox, q_spinbox.value() + q_delta, editing_finished=True)
+    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs

--- a/test/ui/ui_utilities.py
+++ b/test/ui/ui_utilities.py
@@ -17,6 +17,14 @@ def setText(widget, text, press_enter=True):
         widget.returnPressed.emit()
 
 
+def setValue(widget, value, editing_finished=True):
+    r"""Set the value of a widget and optionally emit editing finished signal."""
+    assert getattr(widget, "setValue", None) is not None
+    widget.setValue(value)
+    if editing_finished:
+        widget.editingFinished.emit()
+
+
 def data_from_plot1D(widget: "MplWidget", line_number=0) -> tuple:
     r"""Get the data from an MplWidget representing a 1D plot
     Returns


### PR DESCRIPTION
# Short description of the changes:
There are three configuration widgets in the UI that change global binning for all runs and should trigger recalculating the reflectivity for all runs and replotting the reflectivity curves. This fixes a defect where only the active run was recalculated.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Start QuickNXS and load at least two runs in the reduction table.
Change one of the binning options under the tab "Reflectivity Extraction (Global)" and verify that all runs in the Reflectivity plot are updated).

![image](https://github.com/neutrons/reflectivity_ui/assets/6989921/c6cf7cfe-8566-4148-9c82-e8df1056dec5)

# References
[Defect 4758: [QUICKNXS] Global options updated when selecting a run](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4758)
