### PR TITLE
Add check for ymax in reflectivity plot

### DIFF
--- a/reflectivity_ui/interfaces/plotting.py
+++ b/reflectivity_ui/interfaces/plotting.py
@@ -611,12 +611,19 @@ class PlotManager(object):
                 transform=self.main_window.ui.refl.canvas.ax.transAxes,
             )
         else:
+            def set_ymax(ymax, ynormed):
+                _ymax = max(ymax, ynormed.max())
+                if _ymax == np.inf:
+                    _ymax = np.ma.array(ynormed, mask=~np.isfinite(ynormed)).max()
+                    _ymax = max(ymax, _ymax)
+                return _ymax
+
             ymin = 1.5
             ymax = 1e-7
             ynormed = self.main_window.data_manager.active_channel.r[P0:PN]
             if len(ynormed[ynormed > 0]) >= 2:
                 ymin = min(ymin, ynormed[ynormed > 0].min())
-                ymax = max(ymax, ynormed.max())
+                ymax = set_ymax(ymax, ynormed)
                 self.main_window.ui.refl.errorbar(
                     self.main_window.data_manager.active_channel.q[P0:PN],
                     ynormed,
@@ -652,7 +659,7 @@ class PlotManager(object):
                 except ValueError:
                     pass
                 try:
-                    ymax = max(ymax, ynormed.max())
+                    ymax = set_ymax(ymax, ynormed)
                 except ValueError:
                     pass
                 self.main_window.ui.refl.errorbar(

--- a/reflectivity_ui/interfaces/plotting.py
+++ b/reflectivity_ui/interfaces/plotting.py
@@ -611,6 +611,7 @@ class PlotManager(object):
                 transform=self.main_window.ui.refl.canvas.ax.transAxes,
             )
         else:
+
             def _set_ymax(ymax, ynormed):
                 _ymax = max(ymax, ynormed.max())
                 if _ymax == np.inf:

--- a/reflectivity_ui/interfaces/plotting.py
+++ b/reflectivity_ui/interfaces/plotting.py
@@ -611,7 +611,7 @@ class PlotManager(object):
                 transform=self.main_window.ui.refl.canvas.ax.transAxes,
             )
         else:
-            def set_ymax(ymax, ynormed):
+            def _set_ymax(ymax, ynormed):
                 _ymax = max(ymax, ynormed.max())
                 if _ymax == np.inf:
                     _ymax = np.ma.array(ynormed, mask=~np.isfinite(ynormed)).max()
@@ -623,7 +623,7 @@ class PlotManager(object):
             ynormed = self.main_window.data_manager.active_channel.r[P0:PN]
             if len(ynormed[ynormed > 0]) >= 2:
                 ymin = min(ymin, ynormed[ynormed > 0].min())
-                ymax = set_ymax(ymax, ynormed)
+                ymax = _set_ymax(ymax, ynormed)
                 self.main_window.ui.refl.errorbar(
                     self.main_window.data_manager.active_channel.q[P0:PN],
                     ynormed,
@@ -659,7 +659,7 @@ class PlotManager(object):
                 except ValueError:
                     pass
                 try:
-                    ymax = set_ymax(ymax, ynormed)
+                    ymax = _set_ymax(ymax, ynormed)
                 except ValueError:
                     pass
                 self.main_window.ui.refl.errorbar(


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
When plotting reflectivity there is a possibility that `np.inf` values are in the array when the ymax is taken for setting the y limits of the graph. This adds a check to get the actual max by masking the `np.inf` values in the array. This only masks the values for the purpose of getting the max and does not change or mask any of the data. 

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->
The following steps can be used to reproduce the traceback as tested on the analysis machines. When following the same steps testing this branch you should not see a traceback or error. 

On the analysis cluster, 
- Start quicknxs3
- Set Cut Pts low side to 1
- In "Open Number:" enter 40786
- When the file has been loaded, add it as a direct beam run (button "I(lambda)")
- Select run 40785 in the file list
- When the file has been loaded, add it to the reduction list (button "+")
- Select run 40782 in the file list


# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
[EWM 856](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=856)
