### PR TITLE
Add fallback option for loading data

### DIFF
--- a/reflectivity_ui/interfaces/data_handling/instrument.py
+++ b/reflectivity_ui/interfaces/data_handling/instrument.py
@@ -168,7 +168,6 @@ class Instrument(object):
                 # Only keep good workspaces, and get rid of the rejected events
                 if len(_path_xs_list) == 1 and not "cross_section_id" in _path_xs_list[0].getRun():
                     logging.warning("Could not filter data, using getDI")
-                    print("Could not filter data, using getDI")
                     ws = api.LoadEventNexus(Filename=path, OutputWorkspace="raw_events")
                     path_xs_list = self.dummy_filter_cross_sections(ws, name_prefix=temp_workspace_root_name)
                 else:

--- a/reflectivity_ui/interfaces/data_handling/instrument.py
+++ b/reflectivity_ui/interfaces/data_handling/instrument.py
@@ -133,7 +133,7 @@ class Instrument(object):
                     LogName="loaded_with_getDI",
                     LogText="True",
                     LogType="String",
-                )  
+                )
                 cross_sections.append(_ws)
             except RuntimeError as run_err:
                 logging.error("Could not filter {}: {}\nError: {}".format(pol_state, sys.exc_info()[1], run_err))

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -740,8 +740,10 @@ class DataManager(object):
                     configuration.normalization = None
                     self._nexus_data.update_configuration(conf)
                     self.calculate_reflectivity()
-                self.add_active_to_reduction()
-                logging.info("%s loaded: %s sec [%s]", r_id, time.time() - t_i, time.time() - t_0)
+                if self.add_active_to_reduction():
+                    logging.info("%s loaded: %s sec [%s]", r_id, time.time() - t_i, time.time() - t_0)
+                else:
+                    logging.error("Could not load %s", r_id)
                 if progress:
                     progress.set_value(n_loaded, message="%s loaded" % os.path.basename(run_file), out_of=n_total)
             else:

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -197,6 +197,9 @@ class DataManager(object):
                     self.reduction_states = list(self.data_sets.keys())
                 is_inserted = False
                 q_min, _ = self._nexus_data.get_q_range()
+                if q_min is None:
+                    logging.error("Could not get q range information")
+                    return False
                 for i in range(len(self.reduction_list)):
                     _q_min, _ = self.reduction_list[i].get_q_range()
                     if q_min <= _q_min:


### PR DESCRIPTION
Occasionally, and for older data, the current way of filtering data fails.
In this case, we case use another PV to do the filtering.

This PR also fixed a small bug where the reduction would fail if there was only one cross-section because it was assuming that the return value of the reduction Mantid algo was a iterable.