### PR TITLE
Strip 'v' from version number in conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,8 @@
 {% set description = data.get('description') %}
 {% set url = data.get('url') %}
 # this will reproduce the version from tags to match versioningit
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
+{% set raw_version = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
+{% set version = raw_version.lstrip('v') %}
 {% set version_number = environ.get('GIT_DESCRIBE_NUMBER', '0') | string %}
 
 package:


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [ ] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
