### PR TITLE
Update to mantid 6.10

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: mantid/label/nightly,conda-forge,defaults
+          channels: mantid/label/main,conda-forge,defaults
           python-version: '3.10'
           miniconda-version: latest
           mamba-version: "*"

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ __pycache__/
 .Python
 env/
 build/
-conda.recipe/
 develop-eggs/
 dist/
 downloads/
@@ -25,7 +24,6 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-conda.recipe/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - versioningit
 
   run:
-    - mantid>=6.8.20231103
+    - mantid=6.10.0
     - matplotlib
     - qtpy
     - qt>=5.12,<6

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,6 +12,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 
 **Of interest to the User**:
 
+- PR #104: Update Mantid version to 6.10
 - PR #95: Optional dead-time correction (disabled by default)
 
 **Of interest to the Developer:**

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: quicknxs
 channels:
-    - mantid/label/nightly
+    - mantid/label/main
     - conda-forge
     - default
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - conda-forge
     - default
 dependencies:
-- mantidworkbench>=6.8.20231103
+- mantidworkbench=6.10.0
 - anaconda-client
 - boa
 - build

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ include_package_data = True
 python_requires >= 3.10
 packages = find:
 install_requires =
-    mantid>=6.7
+    mantid>=6.10
     matplotlib
     qtpy
 tests_require =


### PR DESCRIPTION
## Description of work:

The dead-time correction uses the Mantid algorithm `LoadErrorEventsNexus` which requires Mantid 6.10.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
