### PR TITLE
Fix loading workspace with few events with dead-time correction active

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,6 +13,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 **Of interest to the User**:
 
 - PR #115: Skip reflectivity calculation for direct beams
+- PR #112: Make the minimum number of events cut-off configurable in ~/.config/.refredm.conf
 - PR #104: Update Mantid version to 6.10
 - PR #95: Optional dead-time correction (disabled by default)
 - PR #91: Add ability to reduce multiple samples from the same run

--- a/docs/user/advanced_parameters.rst
+++ b/docs/user/advanced_parameters.rst
@@ -1,0 +1,15 @@
+.. _advanced_parameters:
+
+Advanced parameters
+===================
+
+Advanced parameters are only configurable in the local configuration file
+``~/.config/.refredm.conf``.
+
+``nbr_events_min``
+------------------
+
+Default: 100
+
+During loading of data files and direct beam files, any polarization cross-section event workspaces
+with number of events below this cut-off will be ignored.

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -9,3 +9,4 @@ TODO
    :maxdepth: 2
 
    dead_time_correction
+   advanced_parameters

--- a/reflectivity_ui/interfaces/configuration.py
+++ b/reflectivity_ui/interfaces/configuration.py
@@ -44,6 +44,9 @@ class Configuration(object):
     deadtime_tof_step = 100
     # Direct beam uses the same low res roi as the data run
     lock_direct_beam_y = False
+    # Number of events below which we throw away a workspace
+    # Note: not exposed in the UI, but can be modified in ~/.config/.refredm.conf
+    nbr_events_min = 100
 
     def __init__(self, settings=None):
         self.instrument = Instrument()
@@ -241,6 +244,9 @@ class Configuration(object):
         settings.setValue("deadtime_value", self.deadtime_value)
         settings.setValue("deadtime_tof_step", self.deadtime_tof_step)
 
+        # Number of events below which we throw away a workspace
+        settings.setValue("nbr_events_min", self.nbr_events_min)
+
         # Off-specular options
         settings.setValue("off_spec_x_axis", self.off_spec_x_axis)
         settings.setValue("off_spec_slice", self.off_spec_slice)
@@ -346,6 +352,9 @@ class Configuration(object):
         Configuration.deadtime_value = float(settings.value("deadtime_value", self.deadtime_value))
         Configuration.deadtime_tof_step = float(settings.value("deadtime_tof_step", self.deadtime_tof_step))
 
+        # Number of events below which we throw away a workspace
+        Configuration.nbr_events_min = int(settings.value("nbr_events_min", self.nbr_events_min))
+
         # Off-specular options
         self.off_spec_x_axis = int(settings.value("off_spec_x_axis", self.off_spec_x_axis))
         self.off_spec_slice = _verify_true("off_spec_slice", self.off_spec_slice)
@@ -403,6 +412,7 @@ class Configuration(object):
         cls.deadtime_value = 4.2
         cls.deadtime_tof_step = 100
         cls.lock_direct_beam_y = False
+        cls.nbr_events_min = 100
 
 
 def get_direct_beam_low_res_roi(data_conf, direct_beam_conf):

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -431,7 +431,7 @@ class NexusData(object):
 
             # Get rid of empty workspaces
             logging.info("Loading %s: %s events", str(channel), ws.getNumberEvents())
-            if ws.getNumberEvents() < N_EVENTS_CUTOFF:
+            if ws.getNumberEvents() < self.configuration.nbr_events_min:
                 logging.warning("Too few events for %s: %s", channel, ws.getNumberEvents())
                 continue
 

--- a/test/unit/reflectivity_ui/interfaces/data_handling/test_instrument.py
+++ b/test/unit/reflectivity_ui/interfaces/data_handling/test_instrument.py
@@ -59,3 +59,26 @@ def test_mantid_algorithm_exec():
     custom_value = 4
     ws_out = mantid_algorithm_exec(TestMantidAlgo, Value=custom_value, OutputWorkspace="output")
     assert ws_out.readY(0)[0] == custom_value
+
+
+@pytest.mark.datarepo
+def test_load_data_nbr_events_min(data_server):
+    """Test load data with one cross-section with too few events"""
+    conf = Configuration()
+    file_path = data_server.path_to("REF_M_40776")
+
+    # load with no cut-off on number of events
+    conf.nbr_events_min = 0
+    ws_list = conf.instrument.load_data(file_path, conf)
+    assert len(ws_list) == 3
+
+    # load with cut-off on number of events
+    conf.nbr_events_min = 100
+    ws_list = conf.instrument.load_data(file_path, conf)
+    assert len(ws_list) == 2
+
+    # test loading with dead-time correction
+    conf.nbr_events_min = 100
+    conf.apply_deadtime = True
+    ws_list = conf.instrument.load_data(file_path, conf)
+    assert len(ws_list) == 2


### PR DESCRIPTION
## Description of work:

Loading with dead-time correction active gave an error for a polarization cross-section workspace that had only one event.
Such workspaces are filtered out during data loading, but the dead-time correction requires this filtering to occur earlier in the loading process.

Changes:
- make the minimum number of events in a workspace an advanced configuration parameter
- filter out workspaces with too few events before applying dead-time correction
- add user docs on advanced parameters

This is the error that is fixed:

```
Abort-type of error Problem setting "Params" in Rebin-v1: Invalid value for property Params (dbl list) from string "26614.900390625,100.0,26614.900390625": When setting value of property "Params": Bin boundary values must be given in order of increasing value:
<traceback object at 0x7f45b81fe180>
Traceback (most recent call last):
  File "/opt/anaconda/envs/quicknxs2-dev/lib/python3.10/site-packages/mantid/simpleapi.py", line 944, in do_set_property
    alg_object.setProperty(key, new_value)
ValueError: Invalid value for property Params (dbl list) from string "26614.900390625,100.0,26614.900390625": When setting value of property "Params": Bin boundary values must be given in order of increasing value
```

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 8295: [QuickNXS] Loading reduced file raises Exception](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8295)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Load the reduced data file linked in the EWM story.
Note that this PR fixes one of the errors, but this error remains and will be resolved separately:

```
Python-[Error] Could not process 40774_entry_Off_Off
Python-[Error] Variable invalidated, data has been deleted.
MagnetismReflectometryReduction-[Error] Error in execution of algorithm MagnetismReflectometryReduction:
MagnetismReflectometryReduction-[Error] No valida workspace found.
MagnetismReflectometryReduction-[Error]   at line 216 in '/home/u5z/mambaforge/envs/quicknxs/plugins/python/algorithms/MagnetismReflectometryReduction.py'
Reflectivity calculation failed for REF_M_40774.nxs.h5 exception MagnetismReflectometryReduction-v1: No valida workspace found.
  at line 216 in '/home/u5z/mambaforge/envs/quicknxs/plugins/python/algorithms/MagnetismReflectometryReduction.py'
Too few events for On_On: 21
invalid value encountered in divide
```

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
