### PR TITLE
Use the submodule commit as the test data cache key

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,12 +29,19 @@ jobs:
           mamba-version: "*"
           environment-file: environment.yml
 
+      - name: Generate cache key for submodule
+        id: generate-cache-key
+        run: |
+          # Get the submodule commit SHA
+          SUBMODULE_SHA=$(git submodule status | awk '{print $1}' | sha256sum | cut -d ' ' -f 1)
+          echo "SUBMODULE_KEY=$SUBMODULE_SHA" >> $GITHUB_ENV
+
       - name: Restore/save LFS files in cache
         id: cache-lfs
         uses: actions/cache@v4
         with:
           path: test/data/reflectivity_ui-data/
-          key: ${{ runner.os }}-lfs-files
+          key: submodule-${{ env.SUBMODULE_KEY }}
 
       - name: Pull LFS files for the submodule
         if: steps.cache-lfs.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description of work:

To update the CI cached test data files when the data repo refspec changes, change the cache key of the GitHub action `actions/cache` to be based on the data repo submodule refspec.

This does not need a release note since it only affects the CI pipeline.

Check all that apply:
- [ ] ~~added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)~~
- [ ] ~~updated documentation~~
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
