### PR TITLE
Skip reflectivity calculation for direct beams

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,6 +12,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 
 **Of interest to the User**:
 
+- PR #115: Skip reflectivity calculation for direct beams
 - PR #104: Update Mantid version to 6.10
 - PR #95: Optional dead-time correction (disabled by default)
 - PR #91: Add ability to reduce multiple samples from the same run

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -462,6 +462,10 @@ class NexusData(object):
 
         return self.cross_sections
 
+    def is_direct_beam(self):
+        """Returns True if the main cross-section is a direct beam"""
+        return self.cross_sections[self.main_cross_section].is_direct_beam
+
 
 class CrossSectionData(object):
     """

--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -475,10 +475,11 @@ class DataManager(object):
                     self.direct_beam_list[direct_beam_list_id] = nexus_data
 
                 # Compute reflectivity
-                try:
-                    self.calculate_reflectivity()
-                except Exception as e:
-                    logging.error("Reflectivity calculation failed for %s exception %s", file_name, e)
+                if not nexus_data.is_direct_beam():
+                    try:
+                        self.calculate_reflectivity()
+                    except Exception as e:
+                        logging.error("Reflectivity calculation failed for %s exception %s", file_name, e)
 
                 # if cached reduced data exceeds maximum cache size, remove the oldest reduced data
                 while len(self._cache) >= self.MAX_CACHE:

--- a/test/ui/test_missing_cross_section.py
+++ b/test/ui/test_missing_cross_section.py
@@ -24,11 +24,9 @@ def test_missing_cross_section(qtbot):
     intensity_off_on = np.sum(ui_utilities.data_from_plot2D(main_window.xtof_overview))
     # select the On-On spin combination
     main_window.selectedChannel1.click()
-    # check that the reflectivity curve is empty
-    _, data_y = ui_utilities.data_from_plot1D(main_window.refl)
-    test = data_y.data - data_y.data[0]
-    assert np.all(test <= TEST_REFLECTIVITY_THRESHOLD_VALUE)
-    tmp = ui_utilities.data_from_plot2D(main_window.xtof_overview)
+    # check that no reflectivity curve is displayed
+    plot_text = ui_utilities.text_from_plot1D(main_window.refl)
+    assert plot_text == "No data"
     # check the x vs TOF plot has changed
     intensity_on_on = np.sum(ui_utilities.data_from_plot2D(main_window.xtof_overview))
     assert intensity_on_on / intensity_off_on < TEST_REFLECTIVITY_THRESHOLD_VALUE

--- a/test/ui/ui_utilities.py
+++ b/test/ui/ui_utilities.py
@@ -52,7 +52,8 @@ def text_from_plot1D(widget: "MplWidget", line_number=0) -> tuple:
     r"""Get the text from an MplWidget representing a 1D plot
     Returns
     -------
-    X and Y data as a tuple of numpy arrays
+    str
+        The first text that is not a title or label
     """
     figure = widget.canvas.fig
     axes = figure.get_axes()[0]

--- a/test/ui/ui_utilities.py
+++ b/test/ui/ui_utilities.py
@@ -2,6 +2,7 @@
 
 
 # third party imports
+import matplotlib.pyplot as plt
 from numpy.ma import MaskedArray
 from PyQt5 import QtCore
 
@@ -45,6 +46,22 @@ def data_from_plot2D(widget: "MplWidget") -> MaskedArray:
     figure = widget.canvas.fig
     axes = figure.get_axes()[0]
     return axes.get_images()[0].get_array()
+
+
+def text_from_plot1D(widget: "MplWidget", line_number=0) -> tuple:
+    r"""Get the text from an MplWidget representing a 1D plot
+    Returns
+    -------
+    X and Y data as a tuple of numpy arrays
+    """
+    figure = widget.canvas.fig
+    axes = figure.get_axes()[0]
+    texts = [
+        child
+        for child in axes.get_children()
+        if isinstance(child, plt.Text) and child not in [axes.title, axes.xaxis.label, axes.yaxis.label]
+    ]
+    return texts[0].get_text()
 
 
 def set_current_file_by_run_number(widget, run_number):


### PR DESCRIPTION
## Description of work:

Change the data file loading logic to skip calculating the reflectivity curve for runs for which the metadata (`workspace.getRun().getProperty("data_type")`) indicates that it is a direct beam.
 Previously, the reflectivity curve calculation for direct beams has often failed and an error message has been logged, but by skipping the calculation for non-reflected runs we avoid misleading error messages and/or confusing direct beam reflectivity curves.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 8295: [QuickNXS] Loading reduced file raises Exception](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8295)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Start QuickNXS, uncheck apply Dead Time Correction (fixed separately in #112) and load the reduced data file `REF_M_40775+40776+40777_Specular_Off_Off-rebin.dat` (linked in EWM). There should be no log messages about failed reflectivity calculation in the terminal, and when selecting a direct beam run (e.g. 40774) the reflectivity plot on the bottom right should show "No data".

![image](https://github.com/user-attachments/assets/42ccd652-9630-426d-a332-d1d32b9af8dd)


# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
