### PR TITLE
Add missing parentheses to QTabWidget.currentIndex()

### DIFF
--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -1004,7 +1004,7 @@ class DataManager(object):
         tab_index: int
             Index of the peak in `self.peak_reduction_lists`
         """
-        if self.main_reduction_list and tab_index not in self.peak_reduction_lists:
+        if self.main_reduction_list is not None and tab_index not in self.peak_reduction_lists:
             self.peak_reduction_lists[tab_index] = copy.deepcopy(self.main_reduction_list)
 
     def remove_additional_reduction_list(self, tab_index: int):

--- a/reflectivity_ui/interfaces/event_handlers/main_handler.py
+++ b/reflectivity_ui/interfaces/event_handlers/main_handler.py
@@ -77,7 +77,7 @@ class MainHandler(object):
         -------
         QTableWidget
         """
-        if self.ui.tabWidget.currentIndex == self.DIRECT_BEAM_TAB_INDEX:
+        if self.ui.tabWidget.currentIndex() == self.DIRECT_BEAM_TAB_INDEX:
             # get the table for the main data tab
             current_table = self.ui.tabWidget.widget(self.MAIN_DATA_TAB_INDEX).findChild(QtWidgets.QTableWidget)
         else:

--- a/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/reflectivity_ui/interfaces/event_handlers/test_main_handler.py
@@ -231,5 +231,31 @@ def _get_nexus_data():
     return nexus_data
 
 
+def test_reduction_table(qtbot):
+    """Test property reduction_table which is computed based on the selected tab in the UI"""
+    main_window = MainWindow()
+    handler = MainHandler(main_window)
+    data_tab_widget = main_window.ui.tabWidget
+    qtbot.addWidget(main_window)
+
+    # Add second data tab
+    main_window.addDataTable()
+    main_data_table_widget = data_tab_widget.widget(handler.MAIN_DATA_TAB_INDEX).findChild(QtWidgets.QTableWidget)
+    second_data_table_widget = data_tab_widget.widget(2).findChild(QtWidgets.QTableWidget)
+
+    # Test that the main data tab is active by default
+    assert handler.reduction_table == main_data_table_widget
+
+    # When the direct beam tab is active, `reduction_table` should return the main data table widget
+    data_tab_widget.setCurrentIndex(handler.DIRECT_BEAM_TAB_INDEX)
+    assert handler.reduction_table == main_data_table_widget
+
+    # When one of the data tabs is active, `reduction_table` should return the corresponding data table widget
+    data_tab_widget.setCurrentIndex(handler.MAIN_DATA_TAB_INDEX)
+    assert handler.reduction_table == main_data_table_widget
+    data_tab_widget.setCurrentIndex(2)
+    assert handler.reduction_table == second_data_table_widget
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Description of work:

This fixes a bug where the wrong `QTableWidget` was updated due to missing parentheses when getting the active `QTabWidget` tab using `QTabWidget.currentIndex()`. Add the paretheses to get the current index _value_ rather than a reference to the method `currentIndex`.

This does not require a release note since it fixes a bug introduced in the same release.

Check all that apply:
- [ ] ~~added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)~~
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 8195: [QuickNXS] Button "Reload Active File" not working when direct beam table is selected](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8195)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Follow the instructions in EWM for reproducing the bug and verify that the direct beam table is not updated when it shouldn't.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
