### PR TITLE
Recalculate reflectivity for additional data tabs upon global config change

### DIFF
--- a/reflectivity_ui/interfaces/data_manager.py
+++ b/reflectivity_ui/interfaces/data_manager.py
@@ -614,13 +614,14 @@ class DataManager(object):
 
     def reduce_spec(self):
         """
-        Calculate reflectivity for all runs in the reduction list
+        Calculate reflectivity for all runs in all reduction lists
         """
-        for nexus_data in self.reduction_list:
-            try:
-                self.calculate_reflectivity(nexus_data=nexus_data)
-            except:
-                logging.error("Could not compute reflectivity for %s\n  %s", nexus_data.number, sys.exc_info()[1])
+        for reduct_list in self.peak_reduction_lists.values():
+            for nexus_data in reduct_list:
+                try:
+                    self.calculate_reflectivity(nexus_data=nexus_data)
+                except:
+                    logging.error("Could not compute reflectivity for %s\n  %s", nexus_data.number, sys.exc_info()[1])
 
     def reduce_offspec(self, progress=None):
         """

--- a/test/ui/test_reflectivity_extraction_global.py
+++ b/test/ui/test_reflectivity_extraction_global.py
@@ -111,26 +111,26 @@ def test_reflectivity_recalculated_on_config_change(mocker, qtbot):
 
     # add a data tab - it is automatically initialized with the two runs from the first data tab
     main_window.addDataTable()
-    nbr_data_tabs = main_window.data_tab_count
-    assert nbr_data_tabs == 2
+    number_data_tabs = main_window.data_tab_count
+    assert number_data_tabs == 2
 
     # check that all reflectivity curves are recalculated when global binning configuration is changed
 
-    num_runs = 2 * nbr_data_tabs
+    number_runs = 2 * number_data_tabs
 
     # test toggling `fanReflectivity`
     prev_call_count = mock_calculate_reflectivity.call_count
     main_window.ui.fanReflectivity.nextCheckState()
-    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs
+    assert mock_calculate_reflectivity.call_count == prev_call_count + number_runs
 
     # test toggling `final_rebin_checkbox`
     prev_call_count = mock_calculate_reflectivity.call_count
     main_window.ui.final_rebin_checkbox.nextCheckState()
-    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs
+    assert mock_calculate_reflectivity.call_count == prev_call_count + number_runs
 
     # test editing `q_rebin_spinbox`
     prev_call_count = mock_calculate_reflectivity.call_count
     q_spinbox = main_window.ui.q_rebin_spinbox
     q_delta = q_spinbox.singleStep() if q_spinbox.value() < 0 else -q_spinbox.singleStep()
     ui_utilities.setValue(q_spinbox, q_spinbox.value() + q_delta, editing_finished=True)
-    assert mock_calculate_reflectivity.call_count == prev_call_count + num_runs
+    assert mock_calculate_reflectivity.call_count == prev_call_count + number_runs

--- a/test/ui/test_reflectivity_extraction_global.py
+++ b/test/ui/test_reflectivity_extraction_global.py
@@ -109,9 +109,14 @@ def test_reflectivity_recalculated_on_config_change(mocker, qtbot):
     main_window.actionAddPlot.triggered.emit()
     assert mock_calculate_reflectivity.call_count == 2
 
+    # add a data tab - it is automatically initialized with the two runs from the first data tab
+    main_window.addDataTable()
+    nbr_data_tabs = main_window.data_tab_count
+    assert nbr_data_tabs == 2
+
     # check that all reflectivity curves are recalculated when global binning configuration is changed
 
-    num_runs = 2
+    num_runs = 2 * nbr_data_tabs
 
     # test toggling `fanReflectivity`
     prev_call_count = mock_calculate_reflectivity.call_count


### PR DESCRIPTION
## Description of work:

There are global configuration parameters related to binning that when changed requires recalculating the reflectivity curve(s). This fixes a bug affecting the multiple samples functionality where only the active data tab would be recalculated.

This does not require a release note since it fixes a bug introduced in the same release.

Check all that apply:
- [ ] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: _found while working on_ [Defect 8195: [QuickNXS] Button "Reload Active File" not working when direct beam table is selected](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8195)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

1. Load some data e.g. using a reduced data file.
2. Add an additional peak data tab "Data (ROI 2)" using the "+"-button on the bottom right from the reduction table.
![image](https://github.com/user-attachments/assets/ab27dcd6-8967-4106-92ac-a2936cecba20)
3. Change the state of the global option checkbox "Final rebin" 
![image](https://github.com/user-attachments/assets/4b44127b-6154-41ce-8e3e-3c1600ae72e0)
4. Verify that the reflectivity curves for both data tabs have changed.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
